### PR TITLE
requirements.txt: openPMD-api semver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy
 scipy
 numba
 aptools
-openpmd-api
+openpmd-api~=0.12.0


### PR DESCRIPTION
This updated the `requirements.txt` slightly to use [semantic versioning](https://www.python.org/dev/peps/pep-0440/#compatible-release) ([SO](https://stackoverflow.com/questions/39590187/in-requirements-txt-what-does-tilde-equals-mean)).
Follow-up to #12

openPMD-api follows [semantic versioning](https://semver.org/), thus APIs are guaranteed to be compatible for those changes:
- `0.Y.A` -> `0.Y.B`
- `X.A.*` -> `X.B.*`
- `<any>.<any>.*` -> `<any>.<any>.*`

In reality, our APIs expose breaking changes even less often and would often not even affect Wake-T (e.g. we also release a C++ API that is covered under the same SemVer). Nonetheless, I have some ideas on my backlog that I want to improve in the Python API, a few of them would introduce breakage (e.g. https://github.com/openPMD/openPMD-api/issues/808). Updating the `requirements.txt` file manually with a newer major release once it is released (or desired) will ensure stability & reproducibility.

Breaking changes are always documented in [NEWS.rst](https://github.com/openPMD/openPMD-api/blob/dev/NEWS.rst) that is also embedded in the the [manual](https://openpmd-api.readthedocs.io/en/latest/install/upgrade.html). Do not hesitate to @-me, too.

Thanks to the [GitHub dependency resolver](https://github.com/openPMD/openPMD-api/network/dependents?package_id=UGFja2FnZS0xNzQ2MzEwODY%3D) that parses your `requirements.txt`, I also see the dependency to Wake-T, which helps me to keep track during release workflows, so I can help if need be.