### PR TITLE
Add support for more laser pulse profiles

### DIFF
--- a/wake_t/__init__.py
+++ b/wake_t/__init__.py
@@ -4,10 +4,12 @@ __version__ = '0.5.0'
 from .beamline_elements import (PlasmaStage, PlasmaRamp, ActivePlasmaLens,
                                 Drift, Dipole, Quadrupole, Sextupole, Beamline)
 from .physics_models.collective_effects.csr import set_csr_settings
-from .physics_models.laser.laser_pulse import GaussianPulse
+from .physics_models.laser.laser_pulse import (
+    GaussianPulse, LaguerreGaussPulse, FlattenedGaussianPulse)
 from .particles.particle_bunch import ParticleBunch
 
 
 __all__ = ['__version__', 'PlasmaStage', 'PlasmaRamp', 'ActivePlasmaLens',
            'Drift', 'Dipole', 'Quadrupole', 'Sextupole', 'Beamline',
-           'set_csr_settings', 'GaussianPulse', 'ParticleBunch']
+           'set_csr_settings', 'GaussianPulse', 'LaguerreGaussPulse',
+           'FlattenedGaussianPulse', 'ParticleBunch']

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -362,6 +362,9 @@ class FlattenedGaussianPulse(LaserPulse):
         # Initialize parent class.
         super().__init__(l_0)
 
+        # Store parameters.
+        self.xi_c = xi_c
+
         # Ensure that N is an integer.
         N = int(round(N))
         # Calculate effective waist of the Laguerre-Gauss modes, at focus.

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -373,7 +373,7 @@ class FlattenedGaussianPulse(LaserPulse):
         # Sum the Laguerre-Gauss modes that constitute this pulse.
         # See equation (2) and (3) in Santarsiero et al.
         for n in range(N+1):
-            cep_phase_n = cep_phase + (2*n+1)*np.pi/2
+            cep_phase_n = cep_phase + 2*n*np.pi/2
             m_values = np.arange(n, N+1)
             cn = (-1)**n * np.sum(0.5**m_values * binom(m_values, n)) / (N+1)
             pulse = LaguerreGaussPulse(

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -1,9 +1,16 @@
 """
 This module contains the class definitions for different laser pulses.
 
+The implementation of the Laguerre-Gauss and Flattened Gaussian
+profiles, as well as the SummedPulse approach is based on FBPIC
+(https://github.com/fbpic/fbpic).
+
+Authors: Angel Ferran Pousa, Remi Lehe, Manuel Kirchen, Pierre Pelletier.
+
 """
 import numpy as np
 import scipy.constants as ct
+from scipy.special import genlaguerre, binom
 
 from .envelope_solver import evolve_envelope
 
@@ -26,6 +33,10 @@ class LaserPulse():
         self.a_env_old = None
         self.a_env = None
         self.solver_params = None
+
+    def __add__(self, pulse_2):
+        """ Overload the add operator to allow summing of laser pulses. """
+        return SummedPulse(self, pulse_2)
 
     def set_envelope_solver_params(self, xi_min, xi_max, r_max, nz, nr, dt,
                                    nt=1):
@@ -139,6 +150,35 @@ class LaserPulse():
         return np.zeros_like(r)
 
 
+class SummedPulse(LaserPulse):
+    """ Class defining a laser pulse made up of the addition of two pulses. """
+
+    def __init__(self, pulse_1, pulse_2):
+        """
+        Initialize summed pulse.
+
+        Parameters:
+        -----------
+        pulse_1 : LaserPulse
+            A LaserPulse instance.
+        pulse_2 : LaserPulse
+            Another LaserPulse instance to be summed to `pulse_1`.
+        """
+        if pulse_1.l_0 != pulse_2.l_0:
+            raise ValueError(
+                'Only laser pulses with the same central wavelength'
+                ' can currently be summed.')
+        super().__init__(pulse_1.l_0)
+        self.pulse_1 = pulse_1
+        self.pulse_2 = pulse_2
+
+    def envelope_function(self, xi, r, z_pos):
+        """ Return the summed envelope of the two pulses. """
+        a_env_1 = self.pulse_1.envelope_function(xi, r, z_pos)
+        a_env_2 = self.pulse_2.envelope_function(xi, r, z_pos)
+        return a_env_1 + a_env_2
+
+
 class GaussianPulse(LaserPulse):
 
     """ Class defining a Gaussian laser pulse. """
@@ -151,7 +191,7 @@ class GaussianPulse(LaserPulse):
         Parameters:
         -----------
         xi_c : float
-            Central position of the pulse along xi in units of m.
+            Initial central position of the pulse along xi in units of m.
         l_0 : float
             Laser wavelength in units of m.
         w_0 : float
@@ -194,3 +234,154 @@ class GaussianPulse(LaserPulse):
         if self.polarization == 'linear':
             avg_amplitude /= np.sqrt(2)
         return avg_amplitude / diff_factor * gaussian_profile
+
+
+class LaguerreGaussPulse(LaserPulse):
+
+    """ Class defining a Laguerre-Gauss pulse. """
+
+    def __init__(self, xi_c, p, a_0, w_0, tau, z_foc=None,
+                 l_0=0.8e-6, cep_phase=0., polarization='linear'):
+        """
+        Define a Laguerre-Gauss laser profile. Only the `0` azimuthal mode
+        is supported.
+
+        Parameters
+        ----------
+        xi_c : float
+            Initial central position of the pulse along xi in units of m.
+        p: int (positive)
+            The order of the Laguerre polynomial. Increasing ``p`` increases
+            the number of "rings" in the radial intensity profile of the laser.
+        a_0: float (dimensionless)
+            The amplitude of the pulse, defined so that the total
+            energy of the pulse is the same as that of a Gaussian pulse
+            with the same :math:`a_0`, :math:`w_0` and :math:`\\tau`.
+            (i.e. The energy of the pulse is independent of ``p``.)
+        w_0: float (in meter)
+            Laser waist at the focal plane.
+        tau: float (in second)
+            Longitudinal pulse duration (FWHM in intensity).
+        z_foc : float
+            Focal position of the pulse.
+        l_0: float (in meter), optional
+            The wavelength of the laser.
+        cep_phase: float (in radian), optional
+            The Carrier Envelope Phase (CEP), i.e. the phase of the laser
+            oscillation, at the position where the laser envelope is maximum.
+
+        """
+        # Initialize parent class
+        super().__init__(l_0)
+
+        # If no focal plane position is given, use xi_c
+        if z_foc is None:
+            z_foc = xi_c
+
+        # Store the parameters
+        self.p = p
+        self.laguerre_pm = genlaguerre(self.p, 0) # Laguerre polynomial
+        self.z_r = np.pi * w_0**2 / l_0
+        self.z_foc = z_foc
+        self.xi_c = xi_c
+        self.a0 = a_0
+        self.w0 = w_0
+        self.cep_phase = cep_phase
+        self.tau = tau
+        self.polarization = polarization
+
+    def envelope_function(self, xi, r, z_pos):
+        """ Complex envelope of a Laguerre-Gauss beam. """
+        z = xi + z_pos
+        # Diffraction factor, waist and Gouy phase
+        diffract_factor = 1. + 1j * (z - self.z_foc) / self.z_r
+        s_z = self.tau * ct.c / (2*np.sqrt(2*np.log(2))) * np.sqrt(2)
+        w = self.w0 * abs(diffract_factor)
+        psi = np.angle(diffract_factor)
+        # Calculate the scaled radius
+        scaled_radius_squared = 2 * r**2 / w**2
+        # Calculate the argument of the complex exponential
+        exp_argument = - 1j*self.cep_phase \
+            - r**2 / (self.w0**2 * diffract_factor) \
+            - (xi-self.xi_c)**2 / (2*s_z**2) \
+            - 1j*(2*self.p)*psi # *Additional* Gouy phase
+        # Get the transverse profile
+        profile = (np.exp(exp_argument) / diffract_factor
+                   * self.laguerre_pm(scaled_radius_squared))
+
+        a = self.a0 * profile
+        if self.polarization == 'linear':
+            a /= np.sqrt(2)
+        return a
+
+
+class FlattenedGaussianPulse(LaserPulse):
+
+    """Class defining a flattened Gaussian pulse"""
+
+    def __init__(self, xi_c, a_0, w_0, tau, N=6, z_foc=None, l_0=0.8e-6,
+                 cep_phase=0., polarization='linear'):
+        """
+        Define a laser pulse such that the transverse intensity
+        profile is a flattened Gaussian far from focus, and a distribution
+        with rings in the focal plane. (See `Santarsiero et al., J.
+        Modern Optics, 1997 <http://doi.org/10.1080/09500349708232927>`_)
+        Increasing the parameter ``N`` increases the
+        flatness of the transverse profile far from focus,
+        and increases the number of rings in the focal plane.
+
+        Parameters
+        ----------
+        xi_c : float
+            Initial central position of the pulse along xi in units of m.
+        a_0: float (dimensionless)
+            The peak normalized vector potential at the focal plane.
+        w_0: float (in meter)
+            Laser spot size in the focal plane, defined as :math:`w_0` in the
+            above formula.
+        tau: float (in second)
+            Longitudinal pulse duration (FWHM in intensity).
+        N: int
+            Determines the "flatness" of the transverse profile, far from
+            focus.
+            Default: ``N=6`` ; somewhat close to an 8th order supergaussian.
+        z_foc : float
+            Focal position of the pulse.
+        l_0: float (in meter), optional
+            The wavelength of the laser.
+        cep_phase: float (in radian), optional
+            The Carrier Envelope Phase (CEP), i.e. the phase of the laser
+            oscillation, at the position where the laser envelope is maximum.
+
+        """
+        # Initialize parent class
+        super().__init__(l_0)
+
+        # Ensure that N is an integer
+        N = int(round(N))
+        # Calculate effective waist of the Laguerre-Gauss modes, at focus
+        w_foc = w_0*(N+1)**.5
+
+        # Sum the Laguerre-Gauss modes that constitute this pulse
+        # See equation 2 and 3 in Santarsiero et al.
+        for n in range(N+1):
+            cep_phase_n = cep_phase + (2*n+1)*np.pi/2
+            m_values = np.arange(n, N+1)
+            cn = (-1)**n * np.sum((1./2)**m_values * binom(m_values,n)) / (N+1)
+            pulse = LaguerreGaussPulse(
+                xi_c=xi_c, p=n, a_0=cn*a_0, cep_phase=cep_phase_n, w_0=w_foc,
+                tau=tau, z_foc=z_foc, l_0=l_0, polarization=polarization)
+            if n==0:
+                summed_pulse = pulse
+            else:
+                summed_pulse += pulse
+
+        # Register the summed_pulse
+        self.summed_pulse = summed_pulse
+
+
+    def envelope_function(self, xi, r, z_pos):
+        """
+        Complex envelope of the flattened Gaussian beam.
+        """
+        return self.summed_pulse.envelope_function(xi, r, z_pos)


### PR DESCRIPTION
This PR adds support for flattened Gaussian and Laguerre-Gauss pulses. The implementation is strongly based on FBPIC (thanks @RemiLehe, @MKirchen).

## Changes
- Added new `LaserPulse` subclasses `LaguerreGaussPulse`, `FlattenedGaussianPulse` and `SummedPulse`.
- The `SummedPulse` class allows for combining several pulses into one. To simplify this, the `__add__` operator in `LaserPulse` has been overloaded to return a `SummedPulse`.
- Added a `cep_phase` argument to `GaussianPulse` to match the features of the new profiles.
- Changed the order of the `GaussianPulse` arguments to match that of the new profiles.
- The laser wavelength is now `l_0=0.8e-6` by default.
- Small changes in the format of docstrings.
- Added credits to FBPIC and authors.