### PR TITLE
Correct calculation of beam space charge in Baxevanis solver

### DIFF
--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -136,6 +136,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                 rc = ruyten_coef[ir]
                 # Apply correction.
                 rsl_0 += rc * (1. - u_r) * u_r
+                rsl_1 -= rc * (1. - u_r) * u_r
 
             # Add contribution of particle to charge distribution.
             deposition_array[iz_cell + 0, ir_cell + 0] += zsl_0 * rsl_0 * w_i

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -68,17 +68,19 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     """ Calculate charge distribution assuming linear particle shape. """
 
     # Precalculate particle shape coefficients needed to satisfy charge
-    # conservation during deposition (see work by W.M. Ruyten
+    # density conservation during deposition (see work by W.M. Ruyten
     # https://doi.org/10.1006/jcph.1993.1070).
     if use_ruyten:
+        # Calculate the nr + 1 coefficients, where the first one is applied
+        # to the particles located below the first grid point along r.
+        ruyten_coef = np.zeros(nr + 1)
         r_grid = (np.arange(nr) + 0.5) * dr  # Assumes cell-centered in r.
         cell_volume = np.pi * dz * (
                 (r_grid + 0.5 * dr) ** 2 - (r_grid - 0.5 * dr) ** 2)
         cell_volume_norm = cell_volume / (2 * np.pi * dr ** 2 * dz)
         cell_number = np.arange(nr) + 1
-        ruyten_coef = 6. / cell_number * (
+        ruyten_coef[1:] = 6. / cell_number * (
                 np.cumsum(cell_volume_norm) - 0.5 * cell_number ** 2 - 1. / 24)
-        ruyten_coef = np.concatenate( (np.array([0.]), ruyten_coef) )
 
     z_max = z_min + (nz - 1) * dz
     r_max = nr * dr
@@ -153,18 +155,20 @@ def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     """ Calculate charge distribution assuming cubic particle shape. """
 
     # Precalculate particle shape coefficients needed to satisfy charge
-    # conservation during deposition (see work by W.M. Ruyten
-    # # https://doi.org/10.1006/jcph.1993.1070).
+    # density conservation during deposition (see work by W.M. Ruyten
+    # https://doi.org/10.1006/jcph.1993.1070).
     if use_ruyten:
+        # Calculate the nr + 1 coefficients, where the first one is applied
+        # to the particles located below the first grid point along r.
+        ruyten_coef = np.zeros(nr + 1)
         r_grid = (np.arange(nr) + 0.5) * dr  # Assumes cell-centered in r.
         cell_volume = np.pi * dz * (
                 (r_grid + 0.5 * dr) ** 2 - (r_grid - 0.5 * dr) ** 2)
         cell_volume_norm = cell_volume / (2 * np.pi * dr ** 2 * dz)
         cell_number = np.arange(nr) + 1
-        ruyten_coef = 6. / cell_number * (
+        ruyten_coef[1:] = 6. / cell_number * (
                 np.cumsum(cell_volume_norm) - 0.5 * cell_number ** 2 - 0.125)
-        ruyten_coef[0] = 6.*( cell_volume_norm[0] - 0.5 - 239./(15*2**7) )
-        ruyten_coef = np.concatenate( (np.array([0.]), ruyten_coef) )
+        ruyten_coef[1] = 6.*( cell_volume_norm[0] - 0.5 - 239./(15*2**7) )
 
     z_max = z_min + (nz - 1) * dz
     r_max = nr * dr

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -80,7 +80,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                 np.cumsum(cell_volume_norm) - 0.5 * cell_number ** 2 - 1. / 24)
         ruyten_coef = np.concatenate( (np.array([0.]), ruyten_coef) )
 
-    z_max = z_min + nz * dz
+    z_max = z_min + (nz - 1) * dz
     r_max = nr * dr
 
     # Loop over particles.
@@ -166,7 +166,7 @@ def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
         ruyten_coef[0] = 6.*( cell_volume_norm[0] - 0.5 - 239./(15*2**7) )
         ruyten_coef = np.concatenate( (np.array([0.]), ruyten_coef) )
 
-    z_max = z_min + nz * dz
+    z_max = z_min + (nz - 1) * dz
     r_max = nr * dr
 
     # Loop over particles.

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -13,7 +13,8 @@ import numpy as np
 
 
 def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
-                            deposition_array, p_shape='cubic', use_ruyten=False):
+                            deposition_array, p_shape='cubic',
+                            use_ruyten=False):
     """
     Deposit the the weight of each particle of a 3D distribution into a 2D
     grid (cylindrical symmetry).
@@ -52,10 +53,12 @@ def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
     """
     if p_shape == 'linear':
         return deposit_3d_distribution_linear(
-            z, x, y, w, z_min, r_min, nz, nr, dz, dr, deposition_array, use_ruyten)
+            z, x, y, w, z_min, r_min, nz, nr, dz, dr, deposition_array,
+            use_ruyten)
     elif p_shape == 'cubic':
         return deposit_3d_distribution_cubic(
-            z, x, y, w, z_min, r_min, nz, nr, dz, dr, deposition_array, use_ruyten)
+            z, x, y, w, z_min, r_min, nz, nr, dz, dr, deposition_array,
+            use_ruyten)
     else:
         err_string = ("Particle shape '{}' not recognized. ".format(p_shape) +
                       "Possible values are 'linear' or 'cubic'.")
@@ -168,7 +171,7 @@ def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
         cell_number = np.arange(nr) + 1
         ruyten_coef[1:] = 6. / cell_number * (
                 np.cumsum(cell_volume_norm) - 0.5 * cell_number ** 2 - 0.125)
-        ruyten_coef[1] = 6.*( cell_volume_norm[0] - 0.5 - 239./(15*2**7) )
+        ruyten_coef[1] = 6.*(cell_volume_norm[0] - 0.5 - 239./(15*2**7))
 
     z_max = z_min + (nz - 1) * dz
     r_max = nr * dr

--- a/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
@@ -87,7 +87,8 @@ class NonLinearColdFluidWakefield(Wakefield):
         beam_hist = np.zeros((self.n_xi+4, self.n_r+4))
         deposit_3d_distribution(
             xi/s_d, x/s_d, y/s_d, q/ct.e, self.xi_min/s_d, r[0],
-            self.n_xi, self.n_r, dz, dr, beam_hist, p_shape=self.p_shape)
+            self.n_xi, self.n_r, dz, dr, beam_hist, p_shape=self.p_shape,
+            use_ruyten=True)
         beam_hist = beam_hist[2:-2, 2:-2]
 
         n = np.arange(self.n_r)

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -1194,21 +1194,28 @@ def calculate_beam_source_from_particles(
     # Obtain charge distribution (using cubic particle shape by default).
     q_dist = np.zeros((n_xi + 4, n_r + 4))
     deposit_3d_distribution(xi_n, x_n, y_n, w, xi_min, r_min, n_xi, n_r, dxi,
-                            dr, q_dist, p_shape=p_shape)
+                            dr, q_dist, p_shape=p_shape, use_ruyten=True)
 
-    # Remove guard cells
+    # Remove guard cells.
     q_dist = q_dist[2:-2, 2:-2]
 
-    # Calculate radial integral (Eq. (18)) using trapezoidal rule.
-    # First calculate area of trapezoids.
-    tz_area = np.zeros((n_xi, n_r))
-    tz_area[:, 1:] = (q_dist[:, :-1] + q_dist[:, 1:])/2 * dr
-    # Assume q_dist = 0 at exactly r = 0.
-    tz_area[:, 0] = q_dist[:, 0] / 2 * dr / 2
-    # Radial position of the grid points.
+    # Allovate magnetic field array.
+    b_theta = np.zeros((n_xi+4, n_r+4))
+
+    # Radial position of grid points.
     r_grid_g = (0.5 + np.arange(n_r)) * dr
-    # Compute integral.
-    r_int = np.zeros((n_xi+4, n_r+4))
-    # r_int[2:-2, 2:-2] = np.cumsum(tz_area, axis=1) / np.abs(r_grid_g)
-    r_int[2:-2, 2:-2] = np.cumsum(q_dist, axis=1) / np.abs(r_grid_g) * dr
-    return r_int
+
+    # At each grid cell, calculate integral only until cell center by
+    # assuming that half the charge is evenly distributed within the cell
+    # (i.e., substract half the charge)
+    subs = q_dist / 2
+
+    # At the first grid point along r, subtstact an additonal 1/4 of the
+    # charge. This comes from assuming that the density has to be zero on axis.
+    subs[:,0] += q_dist[:,0]/4
+
+    # Calculate field by integration.
+    b_theta[2:-2, 2:-2] = (
+        (np.cumsum(q_dist, axis=1) - subs) * dr / np.abs(r_grid_g))
+
+    return b_theta

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -1209,5 +1209,6 @@ def calculate_beam_source_from_particles(
     r_grid_g = (0.5 + np.arange(n_r)) * dr
     # Compute integral.
     r_int = np.zeros((n_xi+4, n_r+4))
-    r_int[2:-2, 2:-2] = np.cumsum(tz_area, axis=1) / np.abs(r_grid_g)
+    # r_int[2:-2, 2:-2] = np.cumsum(tz_area, axis=1) / np.abs(r_grid_g)
+    r_int[2:-2, 2:-2] = np.cumsum(q_dist, axis=1) / np.abs(r_grid_g) * dr
     return r_int

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -1171,7 +1171,7 @@ def calculate_beam_source_from_particles(
 
     # At the first grid point along r, subtstact an additonal 1/4 of the
     # charge. This comes from assuming that the density has to be zero on axis.
-    subs[:,0] += q_dist[:,0]/4
+    subs[:, 0] += q_dist[:, 0]/4
 
     # Calculate field by integration.
     b_theta[2:-2, 2:-2] = (

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -1132,47 +1132,6 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     return a_i, b_i, a_0, idx
 
 
-def calculate_beam_source(bunch, n_p, n_r, n_xi, r_min, xi_min, dr, dxi,
-                          p_shape):
-    """
-    Return a (nz+4, nr+4) array with the azimuthal magnetic field
-    from a particle distribution. This is Eq. (18) in the original paper.
-
-    """
-    # Plasma skin depth.
-    s_d = ge.plasma_skin_depth(n_p / 1e6)
-
-    # Get and normalize particle coordinate arrays.
-    xi_n = bunch.xi / s_d
-    x_n = bunch.x / s_d
-    y_n = bunch.y / s_d
-
-    # Calculate particle weights.
-    w = - bunch.q / ct.e / (2 * np.pi * dr * dxi * s_d ** 3 * n_p)
-
-    # Obtain charge distribution (using cubic particle shape by default).
-    q_dist = np.zeros((n_xi + 4, n_r + 4))
-    deposit_3d_distribution(xi_n, x_n, y_n, w, xi_min, r_min, n_xi, n_r, dxi,
-                            dr, q_dist, p_shape=p_shape)
-
-    # Remove guard cells
-    q_dist = q_dist[2:-2, 2:-2]
-
-    # Calculate radial integral (Eq. (18)) using trapezoidal rule.
-    # First calculate area of trapezoids.
-    tz_area = np.zeros((n_xi, n_r))
-    tz_area[:, 1:] = (q_dist[:, :-1] + q_dist[:, 1:])/2 * dr
-    # Assume q_dist = 0 at exactly r = 0.
-    tz_area[:, 0] = q_dist[:, 0] / 2 * dr / 2
-    # Radial position of the grid points.
-    r_grid_g = (0.5 + np.arange(n_r)) * dr
-    # Compute integral.
-    r_int = np.zeros((n_xi+4, n_r+4))
-    r_int[2:-2, 2:-2] = np.cumsum(tz_area, axis=1) / np.abs(r_grid_g)
-
-    return r_int
-
-
 def calculate_beam_source_from_particles(
         x, y, xi, q, n_p, n_r, n_xi, r_min, xi_min, dr, dxi, p_shape):
     """


### PR DESCRIPTION
The current way of calculating the azimuthal magnetic field had a problem where it did not take into account the whole charge of the beam, especially when the number of radial grid points along the bunch was small.

This PR fixes this issue as well as other related problems. These include:
* Correct calculation of `b_theta`.
* The use of Ruyten shapes for charge deposition has been reactivated and added as option.
* Several bug fixes in the implementation of the Ruyten shapes.
* The deposition methods now force all the charge to be deposited within the grid boundaries. This avoids having less charge in the edges of the grid, particularly when using `'cubic'` particle shapes.
* Fix small bug in the calculation of `z_max` in the deposition method.