### PR TITLE
adding z dependance to parabolic_coefficient

### DIFF
--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -190,11 +190,14 @@ class PlasmaStage():
             Maximum radial extension of the plasma column. If `None`, the
             plasma extends up to the `r_max` boundary of the simulation box.
 
-        parabolic_coefficient : float
+        parabolic_coefficient : float or callable
             The coefficient for the transverse parabolic density profile. The
             radial density distribution is calculated as
             `n_r = n_p * (1 + parabolic_coefficient * r**2)`, where n_p is the
-            local on-axis plasma density.
+            local on-axis plasma density. If a `float` is provided, the same
+            value will be used throwout the stage. Alternatively, a function 
+            which returns the value of the coefficient at the given position
+            `z` (e.g. `def func(z)`) might also be provided.
 
         p_shape : str
             Particle shape to be used for the beam charge deposition. Possible

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -27,7 +27,8 @@ class Quasistatic2DWakefield(Wakefield):
         self.ppc = ppc
         self.dz_fields = np.inf if dz_fields is None else dz_fields
         self.r_max_plasma = r_max_plasma
-        self.parabolic_coefficient = self._get_parabolic_coefficient_fn(parabolic_coefficient)
+        self.parabolic_coefficient = self._get_parabolic_coefficient_fn(
+            parabolic_coefficient)
         self.p_shape = p_shape
         self.max_gamma = max_gamma
         # Last time at which the fields where requested.
@@ -157,13 +158,14 @@ class Quasistatic2DWakefield(Wakefield):
         return diag_data
 
     def _get_parabolic_coefficient_fn(self, parabolic_coefficient):
-            """ Get parabolic_coefficient profile function """
-            if isinstance(parabolic_coefficient, float):
-                def uniform_parabolic_coefficient(z):
-                    return np.ones_like(z) * parabolic_coefficient
-                return uniform_parabolic_coefficient
-            elif callable(parabolic_coefficient):
-                return parabolic_coefficient
-            else:
-                raise ValueError(
-                    'Type {} not supported for parabolic_coefficient.'.format(type(parabolic_coefficient)))
+        """ Get parabolic_coefficient profile function """
+        if isinstance(parabolic_coefficient, float):
+            def uniform_parabolic_coefficient(z):
+                return np.ones_like(z) * parabolic_coefficient
+            return uniform_parabolic_coefficient
+        elif callable(parabolic_coefficient):
+            return parabolic_coefficient
+        else:
+            raise ValueError(
+                'Type {} not supported for parabolic_coefficient.'.format(
+                    type(parabolic_coefficient)))

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -27,7 +27,7 @@ class Quasistatic2DWakefield(Wakefield):
         self.ppc = ppc
         self.dz_fields = np.inf if dz_fields is None else dz_fields
         self.r_max_plasma = r_max_plasma
-        self.parabolic_coefficient = parabolic_coefficient
+        self.parabolic_coefficient = self._get_parabolic_coefficient_fn(parabolic_coefficient)
         self.p_shape = p_shape
         self.max_gamma = max_gamma
         # Last time at which the fields where requested.
@@ -70,6 +70,7 @@ class Quasistatic2DWakefield(Wakefield):
         else:
             return
         n_p = self.density_function(t*ct.c)
+        parabolic_coefficient_Arr = self.parabolic_coefficient(t*ct.c)
 
         if self.laser is not None:
             # Evolve laser envelope
@@ -88,7 +89,7 @@ class Quasistatic2DWakefield(Wakefield):
         rho, chi, W_r, E_z, xi_arr, r_arr = calculate_wakefields(
             a_env, [x, y, xi, q], self.r_max, self.xi_min, self.xi_max,
             self.n_r, self.n_xi, self.ppc, n_p, r_max_plasma=self.r_max_plasma,
-            parabolic_coefficient=self.parabolic_coefficient,
+            parabolic_coefficient=parabolic_coefficient_Arr,
             p_shape=self.p_shape, max_gamma=self.max_gamma)
 
         E_0 = ge.plasma_cold_non_relativisct_wave_breaking_field(n_p*1e-6)
@@ -154,3 +155,15 @@ class Quasistatic2DWakefield(Wakefield):
             part_boundary_params, current_smoothing, charge_correction)
 
         return diag_data
+
+    def _get_parabolic_coefficient_fn(self, parabolic_coefficient):
+            """ Get parabolic_coefficient profile function """
+            if isinstance(parabolic_coefficient, float):
+                def uniform_parabolic_coefficient(z):
+                    return np.ones_like(z) * parabolic_coefficient
+                return uniform_parabolic_coefficient
+            elif callable(parabolic_coefficient):
+                return parabolic_coefficient
+            else:
+                raise ValueError(
+                    'Type {} not supported for parabolic_coefficient.'.format(type(parabolic_coefficient)))

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -71,7 +71,7 @@ class Quasistatic2DWakefield(Wakefield):
         else:
             return
         n_p = self.density_function(t*ct.c)
-        parabolic_coefficient_Arr = self.parabolic_coefficient(t*ct.c)
+        parabolic_coefficient = self.parabolic_coefficient(t*ct.c)
 
         if self.laser is not None:
             # Evolve laser envelope
@@ -90,7 +90,7 @@ class Quasistatic2DWakefield(Wakefield):
         rho, chi, W_r, E_z, xi_arr, r_arr = calculate_wakefields(
             a_env, [x, y, xi, q], self.r_max, self.xi_min, self.xi_max,
             self.n_r, self.n_xi, self.ppc, n_p, r_max_plasma=self.r_max_plasma,
-            parabolic_coefficient=parabolic_coefficient_Arr,
+            parabolic_coefficient=parabolic_coefficient,
             p_shape=self.p_shape, max_gamma=self.max_gamma)
 
         E_0 = ge.plasma_cold_non_relativisct_wave_breaking_field(n_p*1e-6)


### PR DESCRIPTION
Modified the inclusion of the parabolic_coefficient in the qs_rz_baxevanis model (wakefield.py) to add a z-dependance. This follows the same format as the definition of the density profile n_p in the PlasmaStage module, ie plasma_stage._get_density_profile().

When a constant is passed, then the new function spits out an array of values like the z-array containing the constant at each element. When a function is passed, then the function is evaluated over the z-array and the result passed out as an array. 

The new wakefield.py model has been tested with a low intensity laser pulse in a plasma waveguide and compared to an independent code I wrote which models the propagation of the pulses in an arbitrary plasma density profile. 

For the tests, I tried both a plasma waveguide with a constant parabolic coefficient and waveguides with both increasing and decreasing parabolic coefficients. You can see in the plots below that there is relatively good agreement between the two cases. (Note that the code I wrote does not include effects like frequency variation of the laser pulse during propagation and also, the plasma in the comparison is infinite rather than finite as necessitated by the high density used in the wake-t sims. Still the agreement demonstrates the basic functionality of the z-dependance of the parabolic_coefficient.
<img width="628" alt="Screenshot 2021-09-06 at 12 32 09" src="https://user-images.githubusercontent.com/27694869/132251900-12b4cd8b-2250-49ec-950a-eba61af4071b.png">
<img width="625" alt="Screenshot 2021-09-03 at 15 46 15" src="https://user-images.githubusercontent.com/27694869/132251911-3d4f01eb-36b9-4b74-ab2f-061525f68e59.png">
<img width="920" alt="Screenshot 2021-09-02 at 10 40 51" src="https://user-images.githubusercontent.com/27694869/132251920-94139cb2-fb55-4ff4-b993-f703a94339f8.png">


