### PR TITLE
Rename laser output fields

### DIFF
--- a/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
@@ -201,7 +201,7 @@ class NonLinearColdFluidWakefield(Wakefield):
             [np.ascontiguousarray(self.n_fl.T) * self.current_n_p * (-ct.e)]
             ]
         if self.laser is not None:
-            fld_names += ['a', 'aphi']
+            fld_names += ['a_mod', 'a_phase']
             fld_comps += [None, None]
             fld_arrays += [
                 [np.ascontiguousarray(np.abs(self.laser.get_envelope().T))],

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -138,7 +138,7 @@ class Quasistatic2DWakefield(Wakefield):
             [np.ascontiguousarray(self.rho.T[2:-2, 2:-2]) * self.n_p * (-ct.e)]
             ]
         if self.laser is not None:
-            fld_names += ['a', 'aphi']
+            fld_names += ['a_mod', 'a_phase']
             fld_comps += [None, None]
             fld_arrays += [
                 [np.ascontiguousarray(np.abs(self.laser.get_envelope().T))],


### PR DESCRIPTION
The current names for the laser fields in the openPMD output are not very accurate. This PR renames the modulus of the complex laser envelope from `'a'` to `'a_mod'`, and the complex phase from `'aphi'` to `'a_phase'`.