### PR TITLE
Numba caching

### DIFF
--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -8,7 +8,7 @@ implemented in FBPIC (https://github.com/fbpic/fbpic).
 """
 
 import math
-from numba import njit
+from wake_t.utilities.numba_caching import njit_func
 import numpy as np
 
 
@@ -65,7 +65,7 @@ def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
         raise ValueError(err_string)
 
 
-@njit
+@njit_func
 def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                    deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming linear particle shape. """
@@ -152,7 +152,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     return
 
 
-@njit
+@njit_func
 def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                   deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming cubic particle shape. """

--- a/wake_t/particles/interpolation.py
+++ b/wake_t/particles/interpolation.py
@@ -11,10 +11,11 @@ shapes.
 
 import math
 import numpy as np
-from numba import njit, prange
+from wake_t.utilities.numba_caching import njit_func
+from numba import prange
 
 
-@njit()
+@njit_func
 def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     """
     Interpolate a 2D field defined on an r-z grid to the particle positions
@@ -92,7 +93,7 @@ def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     return fld_part
 
 
-@njit()
+@njit_func
 def gather_main_fields_cyl_linear(wx, ez, z_min, z_max, r_min, r_max, dz, dr,
                                   x, y, z):
     """
@@ -192,7 +193,7 @@ def gather_main_fields_cyl_linear(wx, ez, z_min, z_max, r_min, r_max, dz, dr,
     return wx_part, wy_part, ez_part
 
 
-@njit()
+@njit_func
 def gather_sources_qs_baxevanis(fld_1, fld_2, fld_3, z_min, z_max, r_min,
                                 r_max, dz, dr, r, z):
     """

--- a/wake_t/particles/tracking.py
+++ b/wake_t/particles/tracking.py
@@ -1,6 +1,7 @@
 """ This module contains the numerical trackers and equations of motion """
 
-from numba import njit, prange
+from wake_t.utilities.numba_caching import njit_func
+from numba import prange
 import numpy as np
 import scipy.constants as ct
 
@@ -29,7 +30,7 @@ def equations_of_motion(beam_matrix, t, WF, dt):
     return calculate_derivatives(px, py, pz, wx, wy, wz, dt)
 
 
-@njit()
+@njit_func
 def update_beam_matrix(bm, A, B, C, D):
     inv_6 = 1 / 6.
     for i in prange(bm.shape[0]):
@@ -37,7 +38,7 @@ def update_beam_matrix(bm, A, B, C, D):
             bm[i, j] += (A[i, j] + 2.*(B[i, j] + C[i, j]) + D[i, j]) * inv_6
 
 
-@njit()
+@njit_func
 def calculate_derivatives(px, py, pz, wx, wy, wz, dt):
     n_part = px.shape[0]
     der = np.empty((7, n_part))

--- a/wake_t/physics_models/laser/envelope_solver.py
+++ b/wake_t/physics_models/laser/envelope_solver.py
@@ -7,11 +7,11 @@ Authors: Wilbert den Hertog, Ángel Ferran Pousa, Carlo Benedetti
 """
 
 import numpy as np
-from numba import njit
+from wake_t.utilities.numba_caching import njit_func
 import scipy.constants as ct
 
 
-@njit()
+@njit_func
 def L(sign, k, dr):
     """
     Calculation of L_k^{+-}. Change wrt Benedetti - 2018: in Wake-T we use cell
@@ -43,7 +43,7 @@ def L(sign, k, dr):
             return 0
 
 
-@njit()
+@njit_func
 def C(sign, k, k0p, dt, dz, dr):
     """
     Calculate Equation (8) from Benedetti - 2018.
@@ -68,7 +68,7 @@ def C(sign, k, k0p, dt, dz, dr):
             - sign * 3 / 2 * 1 / (dt * dz) - 1 / dt ** 2)
 
 
-@njit()
+@njit_func
 def D(th, th1, th2, dz):
     """
     Calculate D in Equation (6) from Benedetti - 2018
@@ -104,7 +104,7 @@ def D(th, th1, th2, dz):
     return 1.5 * d_theta1 / dz - 0.5 * d_theta2 / dz
 
 
-@njit()
+@njit_func
 def rhs(a_old, a, a_new, chi, j, dz, k, dr, nr, dt, k0p, th, th1, th2):
     """
     The right-hand side of equation 7 in Benedetti, 2018.
@@ -157,7 +157,7 @@ def rhs(a_old, a, a_new, chi, j, dz, k, dr, nr, dt, k0p, th, th1, th2):
     return sol
 
 
-@njit()
+@njit_func
 def TDMA(a, b, c, d):
     """TriDiagonal Matrix Algorithm: solve a linear system Ax=b,
     where A is a tridiagonal matrix. Source:
@@ -194,7 +194,7 @@ def TDMA(a, b, c, d):
     return p
 
 
-@njit()
+@njit_func
 def evolve_envelope(a0, aold, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
                     start_outside_plasma=False):
     """

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -8,7 +8,7 @@ for the full details about this model.
 
 import numpy as np
 import scipy.constants as ct
-from numba import njit
+from wake_t.utilities.numba_caching import njit_func
 import aptools.plasma_accel.general_equations as ge
 
 from wake_t.particles.deposition import deposit_3d_distribution
@@ -290,7 +290,7 @@ def motion_derivatives(dxi, dr_p, xi, r, pr, q, a2_rz, nabla_a2_rz,
     return dr, dpr
 
 
-@njit()
+@njit_func
 def calculate_derivatives(dxi, dr_p, r_max, r, pr, q, b_theta_0, nabla_a2, a2,
                           pc):
     """
@@ -360,7 +360,7 @@ def calculate_derivatives(dxi, dr_p, r_max, r, pr, q, b_theta_0, nabla_a2, a2,
     return dr, dpr
 
 
-@njit()
+@njit_func
 def update_particles_rk4(r, pr, Ar, Br, Cr, Dr, Apr, Bpr, Cpr, Dpr):
     """
     Jittable method to which updating the particle coordinates in the RK4
@@ -382,7 +382,7 @@ def update_particles_rk4(r, pr, Ar, Br, Cr, Dr, Apr, Bpr, Cpr, Dpr):
     return
 
 
-@njit
+@njit_func
 def update_gamma_and_pz(gamma, pz, pr, a2, psi):
     """
     Update the gamma factor and longitudinal momentum of the plasma particles.
@@ -403,7 +403,7 @@ def update_gamma_and_pz(gamma, pz, pr, a2, psi):
         pz[i] = (1 + pr[i]**2 + a2[i] - (1+psi[i])**2) / (2 * (1+psi[i]))
 
 
-@njit()
+@njit_func
 def calculate_psi_and_derivatives_at_particles(r, pr, q, r_max, dr_p, pc):
     """
     Calculate the wakefield potential and its derivatives at the position
@@ -562,7 +562,7 @@ def calculate_psi_and_derivatives_at_particles(r, pr, q, r_max, dr_p, pc):
     return psi, dr_psi, dxi_psi
 
 
-@njit()
+@njit_func
 def calculate_psi(r_fld, r, q, r_max, pc):
     """
     Calculate the wakefield potential at the radial
@@ -637,7 +637,7 @@ def calculate_psi(r_fld, r, q, r_max, pc):
     return psi
 
 
-@njit()
+@njit_func
 def delta_psi_eq(r, sum_1, sum_2, r_max, pc):
     """ Adapted equation (29) from original paper. """
     delta_psi_elec = sum_1*np.log(r) - sum_2
@@ -651,7 +651,7 @@ def delta_psi_eq(r, sum_1, sum_2, r_max, pc):
     return delta_psi_elec - delta_psi_ion
 
 
-@njit()
+@njit_func
 def dr_psi_eq(r, sum_1, r_max, pc):
     """ Adapted equation (31) from original paper. """
     dr_psi_elec = sum_1 / r
@@ -662,7 +662,7 @@ def dr_psi_eq(r, sum_1, r_max, pc):
     return dr_psi_elec - dr_psi_ion
 
 
-@njit()
+@njit_func
 def calculate_psi_and_derivatives(r_fld, r, pr, q):
     """
     Calculate the wakefield potential and its derivatives at the radial
@@ -750,7 +750,7 @@ def calculate_psi_and_derivatives(r_fld, r, pr, q):
     return psi, dr_psi, dxi_psi
 
 
-@njit()
+@njit_func
 def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
                                    b_theta_0, nabla_a2, dr_p):
     """
@@ -831,7 +831,7 @@ def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
     return b_theta_bar
 
 
-@njit()
+@njit_func
 def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                       nabla_a2):
     """
@@ -887,7 +887,7 @@ def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     return b_theta_mesh
 
 
-@njit()
+@njit_func
 def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                               nabla_a2):
     """
@@ -1001,7 +1001,7 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     return a_i, b_i, a_0, idx
 
 
-@njit()
+@njit_func
 def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                               nabla_a2):
     """

--- a/wake_t/utilities/numba_caching.py
+++ b/wake_t/utilities/numba_caching.py
@@ -1,0 +1,12 @@
+import os
+from numba import njit
+
+# Check if the environment variable WAKET_DISABLE_CACHING is set to 1
+# and in that case, disable threading
+caching = True
+if 'WAKET_DISABLE_CACHING' in os.environ:
+    if int(os.environ['WAKET_DISABLE_CACHING']) == 1:
+        caching = False
+
+# Set the function njit
+njit_func = njit(cache=caching)

--- a/wake_t/utilities/numba_caching.py
+++ b/wake_t/utilities/numba_caching.py
@@ -2,7 +2,7 @@ import os
 from numba import njit
 
 # Check if the environment variable WAKET_DISABLE_CACHING is set to 1
-# and in that case, disable threading
+# and in that case, disable caching
 caching = True
 if 'WAKET_DISABLE_CACHING' in os.environ:
     if int(os.environ['WAKET_DISABLE_CACHING']) == 1:


### PR DESCRIPTION
Replace all instances of `@njit` with the wrapper function `@njit_func`.
`njit_func` is defined in `numba_caching.py` and equals to numba's `njit` with the option `cache=True` by default.
Numba caching can be disabled by setting the environment variable `WAKET_DISABLE_CACHING=1`.
