### PR TITLE
Fix bug in `Beamline` when using `out_initial=True`

### DIFF
--- a/wake_t/beamline_elements/beamline.py
+++ b/wake_t/beamline_elements/beamline.py
@@ -43,11 +43,14 @@ class Beamline():
 
         """
         bunch_list = []
-        if out_initial:
-            bunch_list.append(copy(bunch))
         if type(opmd_diag) is not OpenPMDDiagnostics and opmd_diag:
             opmd_diag = OpenPMDDiagnostics(write_dir=diag_dir)
-        for element in self.elements:
+        for i, element in enumerate(self.elements):
             bunch_list.extend(
-                element.track(bunch, out_initial=False, opmd_diag=opmd_diag))
+                element.track(
+                    bunch,
+                    out_initial=out_initial and i == 0,
+                    opmd_diag=opmd_diag
+                    )
+                )
         return bunch_list

--- a/wake_t/beamline_elements/beamline.py
+++ b/wake_t/beamline_elements/beamline.py
@@ -1,5 +1,3 @@
-from copy import copy
-
 from wake_t.diagnostics import OpenPMDDiagnostics
 
 


### PR DESCRIPTION
This PR fixes an issue in the `Beamline` element where the initial beam distribution would not be included in the openPMD diagnostics when `out_initial=True`.