### PR TITLE
Change default `n_out` and fix crash

### DIFF
--- a/wake_t/beamline_elements/active_plasma_lens.py
+++ b/wake_t/beamline_elements/active_plasma_lens.py
@@ -13,7 +13,7 @@ class ActivePlasmaLens(PlasmaStage):
     """ Convenience class to define an active plasma lens. """
 
     def __init__(self, length, foc_strength, wakefields=False, density=None,
-                 wakefield_model='quasistatic_2d', n_out=None, **model_params):
+                 wakefield_model='quasistatic_2d', n_out=1, **model_params):
         """
         Initialize plasma lens.
 

--- a/wake_t/beamline_elements/plasma_ramp.py
+++ b/wake_t/beamline_elements/plasma_ramp.py
@@ -46,7 +46,7 @@ class PlasmaRamp(PlasmaStage):
     def __init__(self, length, profile='inverse_square', ramp_type='upramp',
                  wakefield_model='focusing_blowout', decay_length=None,
                  plasma_dens_top=None, plasma_dens_down=None,
-                 position_down=None, n_out=None, **model_params):
+                 position_down=None, n_out=1, **model_params):
         """
         Initialize plasma ramp.
 

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -27,7 +27,7 @@ class PlasmaStage():
     """ Generic class for defining a plasma acceleration stage. """
 
     def __init__(self, length, density, wakefield_model='simple_blowout',
-                 n_out=None, **model_params):
+                 n_out=1, **model_params):
         """
         Initialize plasma stage.
 
@@ -293,7 +293,7 @@ class PlasmaStage():
 
         st_0 = "Tracking in {} step(s)... ".format(self.n_out)
         for s in np.arange(self.n_out):
-            print_progress_bar(st_0, s, self.n_out-1)
+            print_progress_bar(st_0, s+1, self.n_out)
             # if auto_update_fields:
             #    self.wakefield.check_if_update_fields(s*t_step)
             bunch_matrix = runge_kutta_4(


### PR DESCRIPTION
The simulation of plasma elements used to crash when `n_out < 2` due to a mistake in the implementation of the progress bar. In addition to fixing this issue, this PR changes the default `n_out` to `1`, which also fixes a crash when the previous default value of `None` was used.