### PR TITLE
Require Python >= 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,4 +25,4 @@ install_requires =
     scipy
     aptools>=0.1.23
     openpmd-api~=0.14.0
-python_requires = >=3.8
+python_requires = >=3.7


### PR DESCRIPTION
Issues were observed when installing Wake-T with Python <= 3.6: pip would try many scipy versions, and always fail in the installation. This PR proposes to require a newer Python version, with which the problem doesn't appear.