### PR TITLE
Improve functionality of `save_bunch_to_file`

### DIFF
--- a/wake_t/utilities/bunch_saving.py
+++ b/wake_t/utilities/bunch_saving.py
@@ -25,7 +25,7 @@ def save_bunch_to_file(
         under which the bunch data will be stored. If None, the name of the
         bunch will be used.
     reposition : bool, optional
-        Whether to reposition de particle distribution in space
+        Whether to reposition the particle distribution in space
         and/or momentum centered in the coordinates specified in `avg_pos` and
         `avg_mom`. By default False.
     avg_pos : list, optional
@@ -50,9 +50,19 @@ def save_bunch_to_file(
         randomly. The charge of the saved particles will be modified to
         preserve the total charge.
     """
+    # Get bunch data.
     bunch_data = bunch.get_bunch_matrix()
-    if species_name is None:
-        species_name = bunch.name
-    ds.save_beam(data_format, bunch_data, folder_path, file_name,
-                 reposition=reposition, avg_pos=avg_pos, avg_mom=avg_mom,
-                 n_part=n_part, species_name=species_name)
+
+    # For openpmd output, save with species name.
+    if data_format == 'openpmd':
+        if species_name is None:
+            species_name = bunch.name
+        ds.save_beam(
+            data_format, bunch_data, folder_path, file_name,
+            reposition=reposition, avg_pos=avg_pos, avg_mom=avg_mom,
+            n_part=n_part, species_name=species_name)
+    else:
+        ds.save_beam(
+            data_format, bunch_data, folder_path, file_name,
+            reposition=reposition, avg_pos=avg_pos, avg_mom=avg_mom,
+            n_part=n_part)


### PR DESCRIPTION
When saving a `ParticleBunch` to an openpmd file using `save_bunch_to_file`, the name of the particle species stored in the file will now be the same as the bunch name by default, and no longer the generic name `'particle_beam'`. The name of the species can also be specified by the user using the `species_name` parameter, in which case the `ParticleBunch` name will be ignored.

In addition to this change, this PR also add the option of repositioning the saved bunch in momentum space, exposing the `avg_mom` parameter. A detailed docstring for `save_bunch_to_file` has also been added.