### PR TITLE
Improve performance of Baxevanis wakefield model

### DIFF
--- a/tests/test_active_plasma_lens.py
+++ b/tests/test_active_plasma_lens.py
@@ -64,7 +64,7 @@ def test_active_plasma_lens_with_wakefields():
     # Analyze and check results.
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 77.32019450299197
+    assert approx(gamma_x, rel=1e-10) == 77.32005041792752
 
 
 if __name__ == '__main__':

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -87,7 +87,7 @@ def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
 
 @njit()
 def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
-                      nabla_a2, idx):
+                      nabla_a2, idx, b_theta, k):
     """
     Calculate the azimuthal magnetic field from the plasma at the radial
     locations in r_fld using Eqs. (24), (26) and (27) from the paper
@@ -114,6 +114,14 @@ def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     idx : ndarray
         Array containing the (radially) sorted indices of the plasma particles.
 
+    b_theta : ndarray
+        Array where the values of the plasma azimuthal magnetic field will be
+        stored.
+
+    k : int
+        Index that determines the slice of b_theta where the values will
+        be filled in (the index is k-2 due to the guard cells in the array).
+
     """
     # Calculate a_i and b_i, as well as a_0 and the sorted particle indices.
     a_i, b_i, a_0 = calculate_ai_bi_from_edge(
@@ -122,7 +130,7 @@ def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     # Calculate fields at r_fld
     n_part = r.shape[0]
     n_points = r_fld.shape[0]
-    b_theta_mesh = np.zeros(n_points)
+    b_theta_mesh = b_theta[k-2]
     i_last = 0
     for j in range(n_points):
         r_j = r_fld[j]
@@ -137,13 +145,11 @@ def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                 break
         # Calculate fields.
         if i_last == -1:
-            b_theta_mesh[j] = a_0 * r_j
+            b_theta_mesh[2+j] = a_0 * r_j
             i_last = 0
         else:
             i_p = idx[i_last]
-            b_theta_mesh[j] = a_i[i_p] * r_j + b_i[i_p] / r_j
-
-    return b_theta_mesh
+            b_theta_mesh[2+j] = a_i[i_p] * r_j + b_i[i_p] / r_j
 
 
 @njit()

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/deposition.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/deposition.py
@@ -8,6 +8,7 @@ import math
 from numba import njit
 
 
+@njit()
 def deposit_plasma_particles(z, r, w, z_min, r_min, nz, nr, dz, dr,
                              deposition_array, p_shape='cubic'):
     """
@@ -55,10 +56,6 @@ def deposit_plasma_particles(z, r, w, z_min, r_min, nz, nr, dz, dr,
     elif p_shape == 'cubic':
         return deposit_plasma_particles_cubic(
             z, r, w, z_min, r_min, nz, nr, dz, dr, deposition_array)
-    else:
-        err_string = ("Particle shape '{}' not recognized. ".format(p_shape) +
-                      "Possible values are 'linear' or 'cubic'.")
-        raise ValueError(err_string)
 
 
 @njit

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
@@ -37,7 +37,6 @@ def evolve_plasma_ab5(
         psi_pp, dr_psi_pp, dr_1, dpr_1
     )
 
-
     # Push radial position.
     apply_ab5(r, dxi, dr_1, dr_2, dr_3, dr_4, dr_5)
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
@@ -5,54 +5,71 @@ import numpy as np
 from numba import njit
 
 
-def evolve_plasma_ab5(pp, dxi):
+@njit()
+def evolve_plasma_ab5(
+        dxi, r, pr, gamma,
+        nabla_a2_pp, b_theta_0_pp, b_theta_pp, psi_pp, dr_psi_pp,
+        dr_1, dr_2, dr_3, dr_4, dr_5, dpr_1, dpr_2, dpr_3, dpr_4, dpr_5):
     """
     Evolve the r and pr coordinates of plasma particles to the next xi step
     using an Adams–Bashforth method of 5th order.
 
-    Parameters:
-    -----------
-    pp : PlasmaParticles
-        The plasma particles to be evolved.
+    Parameters
+    ----------
     dxi : float
         Longitudinal step.
+    r, pr, gamma : ndarray
+        Radial position, radial momentum, and Lorentz factor of the plasma
+        particles.
+    a2_pp, ..., dxi_psi_pp : ndarray
+        Arrays where the value of the fields at the particle positions will
+        be stored.
+    dr_1, ..., dr_5 : ndarray
+        Arrays containing the derivative of the radial position of the
+        particles at the 5 slices previous to the next one.
+    dpr_1, ..., dpr_5 : ndarray
+        Arrays containing the derivative of the radial momentum of the
+        particles at the 5 slices previous to the next one.
     """
-    # Get fields at the position of plasma particles in current slice.
-    (a2_pp, nabla_a2_pp, b_theta_0_pp, b_theta_pp, psi_pp, dr_psi_pp,
-     dxi_psi_pp) = pp.get_field_arrays()
 
-    # Using these fields, compute derivatives of r and pr at the current slice.
-    dr_arrays, dpr_arrays = pp.get_ab5_arrays()
-    dr_pp = dr_arrays[0]
-    dpr_pp = dpr_arrays[0]
     calculate_derivatives(
-        pp.pr, pp.gamma, b_theta_0_pp, nabla_a2_pp, b_theta_pp,
-        psi_pp, dr_psi_pp, dr_pp, dpr_pp
+        pr, gamma, b_theta_0_pp, nabla_a2_pp, b_theta_pp,
+        psi_pp, dr_psi_pp, dr_1, dpr_1
     )
 
-    # Get derivatives of r and pr of last 5 steps.
-    dr_arrays, dpr_arrays = pp.get_ab5_arrays()
 
     # Push radial position.
-    apply_ab5(pp.r, dxi, *dr_arrays)
+    apply_ab5(r, dxi, dr_1, dr_2, dr_3, dr_4, dr_5)
 
     # Push radial momentum.
-    apply_ab5(pp.pr, dxi, *dpr_arrays)
+    apply_ab5(pr, dxi, dpr_1, dpr_2, dpr_3, dpr_4, dpr_5)
 
     # Shift derivatives for next step (i.e., the derivative at step i will be
     # the derivative at step i+i in the next iteration.)
-    for i in reversed(range(len(dr_arrays)-1)):
-        dr_arrays[i+1][:] = dr_arrays[i]
-        dpr_arrays[i+1][:] = dpr_arrays[i]
+    dr_5[:] = dr_4
+    dr_4[:] = dr_3
+    dr_3[:] = dr_2
+    dr_2[:] = dr_1
+    dpr_5[:] = dpr_4
+    dpr_4[:] = dpr_3
+    dpr_3[:] = dpr_2
+    dpr_2[:] = dpr_1
 
     # If a particle has crossed the axis, mirror it.
-    idx_neg = np.where(pp.r < 0.)
+    idx_neg = np.where(r < 0.)
     if idx_neg[0].size > 0:
-        pp.r[idx_neg] *= -1.
-        pp.pr[idx_neg] *= -1.
-        for i in range(len(dr_arrays)):
-            dr_arrays[i][idx_neg] *= -1.
-            dpr_arrays[i][idx_neg] *= -1.
+        r[idx_neg] *= -1.
+        pr[idx_neg] *= -1.
+        dr_1[idx_neg] *= -1.
+        dr_2[idx_neg] *= -1.
+        dr_3[idx_neg] *= -1.
+        dr_4[idx_neg] *= -1.
+        dr_5[idx_neg] *= -1.
+        dpr_1[idx_neg] *= -1.
+        dpr_2[idx_neg] *= -1.
+        dpr_3[idx_neg] *= -1.
+        dpr_4[idx_neg] *= -1.
+        dpr_5[idx_neg] *= -1.
 
 
 @njit()

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
@@ -56,20 +56,20 @@ def evolve_plasma_rk4(
 
     # Calculate derivatives of r and pr at the three RK4 substeps.
     derivatives_substep(
-        xi, r + dxi * dr_1 * 0.5, pr + dxi * dpr_1 * 0.5, q, dxi, dr,
-        r_max_plasma, dr_p, parabolic_coefficient,
+        xi - dxi * 0.5, r + dxi * dr_1 * 0.5, pr + dxi * dpr_1 * 0.5, q,
+        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_2, nabla_a2_2, b_t_0_2, b_t_2, psi_2, dr_psi_2, dxi_psi_2,
         dr_2, dpr_2)
     derivatives_substep(
-        xi, r + dxi * dr_2 * 0.5, pr + dxi * dpr_2 * 0.5, q, dxi, dr,
-        r_max_plasma, dr_p, parabolic_coefficient,
+        xi - dxi * 0.5, r + dxi * dr_2 * 0.5, pr + dxi * dpr_2 * 0.5, q,
+        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_3, nabla_a2_3, b_t_0_3, b_t_3, psi_3, dr_psi_3, dxi_psi_3,
         dr_3, dpr_3)
     derivatives_substep(
-        xi, r + dxi * dr_3, pr + dxi * dpr_3, q, dxi, dr,
-        r_max_plasma, dr_p, parabolic_coefficient,
+        xi - dxi, r + dxi * dr_3, pr + dxi * dpr_3, q,
+        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4,
         dr_4, dpr_4)

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
@@ -8,7 +8,7 @@ from ..b_theta import calculate_b_theta_at_particles
 
 @njit()
 def evolve_plasma_rk4(
-        dxi, dr, xi, r, pr, gamma, q, r_max_plasma, dr_p, parabolic_coefficient,
+        dxi, dr, xi, r, pr, gamma, q, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         dr_1, dr_2, dr_3, dr_4, dpr_1, dpr_2, dpr_3, dpr_4,
         a2_1, nabla_a2_1, b_t_0_1, b_t_1, psi_1, dr_psi_1, dxi_psi_1,
@@ -32,7 +32,7 @@ def evolve_plasma_rk4(
         Maximum radial extent of the plasma
     dr_p : float
         Initial radial spacing between plasma particles.
-    parabolic_coefficient : float
+    pc : float
         Coefficient for the parabolic radial plasma profile.
     a2, nabla_a2, b_t_0 : ndarray
         Laser and beam source fields.
@@ -57,19 +57,19 @@ def evolve_plasma_rk4(
     # Calculate derivatives of r and pr at the three RK4 substeps.
     derivatives_substep(
         xi - dxi * 0.5, r + dxi * dr_1 * 0.5, pr + dxi * dpr_1 * 0.5, q,
-        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
+        dxi, dr, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_2, nabla_a2_2, b_t_0_2, b_t_2, psi_2, dr_psi_2, dxi_psi_2,
         dr_2, dpr_2)
     derivatives_substep(
         xi - dxi * 0.5, r + dxi * dr_2 * 0.5, pr + dxi * dpr_2 * 0.5, q,
-        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
+        dxi, dr, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_3, nabla_a2_3, b_t_0_3, b_t_3, psi_3, dr_psi_3, dxi_psi_3,
         dr_3, dpr_3)
     derivatives_substep(
         xi - dxi, r + dxi * dr_3, pr + dxi * dpr_3, q,
-        dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
+        dxi, dr, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4,
         dr_4, dpr_4)
@@ -87,7 +87,7 @@ def evolve_plasma_rk4(
 
 @njit()
 def derivatives_substep(
-        xi, r, pr, q, dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
+        xi, r, pr, q, dxi, dr, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
         a2_i, nabla_a2_i, b_t_0_i, b_t_i, psi_i, dr_psi_i, dxi_psi_i,
         dr_i, dpr_i):
@@ -112,7 +112,7 @@ def derivatives_substep(
         Maximum radial extent of the plasma
     dr_p : float
         Initial radial spacing between plasma particles.
-    parabolic_coefficient : float
+    pc : float
         Coefficient for the parabolic radial plasma profile.
     a2, nabla_a2, b_t_0 : ndarray
         Laser and beam source fields.
@@ -143,7 +143,7 @@ def derivatives_substep(
 
     # Calculate wakefield potential and derivatives at plasma particles.
     calculate_psi_and_derivatives_at_particles(
-        r, pr, q, idx, r_max_plasma, dr_p, parabolic_coefficient,
+        r, pr, q, idx, r_max_plasma, dr_p, pc,
         psi_i, dr_psi_i, dxi_psi_i)
 
     # Calculate gamma of plasma particles

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
@@ -6,162 +6,173 @@ from ..psi_and_derivatives import calculate_psi_and_derivatives_at_particles
 from ..b_theta import calculate_b_theta_at_particles
 
 
-def evolve_plasma_rk4(pp, dxi, xi, a2, nabla_a2, b_theta_0, r_fld, xi_fld):
+@njit()
+def evolve_plasma_rk4(
+        dxi, dr, xi, r, pr, gamma, q, r_max_plasma, dr_p, parabolic_coefficient,
+        a2, nabla_a2, b_t_0, r_fld, xi_fld,
+        dr_1, dr_2, dr_3, dr_4, dpr_1, dpr_2, dpr_3, dpr_4,
+        a2_1, nabla_a2_1, b_t_0_1, b_t_1, psi_1, dr_psi_1, dxi_psi_1,
+        a2_2, nabla_a2_2, b_t_0_2, b_t_2, psi_2, dr_psi_2, dxi_psi_2,
+        a2_3, nabla_a2_3, b_t_0_3, b_t_3, psi_3, dr_psi_3, dxi_psi_3,
+        a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4):
     """
     Evolve the r and pr coordinates of plasma particles to the next xi step
     using a Runge-Kutta method of 4th order.
 
-    Parameters:
-    -----------
-
-    pp : PlasmaParticles
-        The plasma particles to be evolved.
-    dxi : float
-        Longitudinal step.
+    Parameters
+    ----------
+    dxi, dr : float
+        Longitudinal and radial step.
     xi : float
-        Current xi position (speed-of-light frame) of the plasma particles.
-    a2 : ndarray
-        2D array with the square of the laser envelope in the r-z grid.
-    nabla_a2 : ndarray
-        2D array with the radial derivative of the square of the laser envelope
-        in the r-z grid.
-    b_theta_0 : ndarray
-        2D array with the azimuthal magnetic field of the electron beam(s)
-        in the r-z grid.
-    r_fld : ndarray
-        Array containing the radial position of the grid points.
-    xi_fld : ndarray
-        Array containing the longitudinal position of the grid points.
+        Current longitudinal position of the plasma slice.
+    r, pr, gamma, q : ndarray
+        Radial position, radial momentum, Lorentz factor and charge of the
+        plasma particles.
+    r_max_plasma : float
+        Maximum radial extent of the plasma
+    dr_p : float
+        Initial radial spacing between plasma particles.
+    parabolic_coefficient : float
+        Coefficient for the parabolic radial plasma profile.
+    a2, nabla_a2, b_t_0 : ndarray
+        Laser and beam source fields.
+    xi_fld, r_fld : ndarray
+        Grid coordinates
+    dr_1, ..., dr_4 : ndarray
+        Arrays containing the derivative of the radial position of the
+        particles at the current slice and the 3 intermediate steps.
+    dpr_1, ..., dpr_4 : ndarray
+        Arrays containing the derivative of the radial momentum of the
+        particles at the current slice and the 3 intermediate steps.
+    a2_i, ..., dxi_psi_i : ndarray
+        Arrays where the field values at the particle positions at substep i
+        will be stored.
     """
-    # Calculate derivatives of r and pr at the 4 substeps.
-    for i in range(4):
-        derivatives_substep(i, pp, xi, a2, nabla_a2, b_theta_0, r_fld, xi_fld)
+    # Calculate derivatives of r and pr at the current slice.
+    calculate_derivatives(
+        pr, gamma,
+        b_t_0_1, nabla_a2_1, b_t_1, psi_1, dr_psi_1,
+        dr_1, dpr_1)
 
-    dr_arrays, dpr_arrays = pp.get_rk4_arrays()
+    # Calculate derivatives of r and pr at the three RK4 substeps.
+    derivatives_substep(
+        xi, r + dxi * dr_1 * 0.5, pr + dxi * dpr_1 * 0.5, q, dxi, dr,
+        r_max_plasma, dr_p, parabolic_coefficient,
+        a2, nabla_a2, b_t_0, r_fld, xi_fld,
+        a2_2, nabla_a2_2, b_t_0_2, b_t_2, psi_2, dr_psi_2, dxi_psi_2,
+        dr_2, dpr_2)
+    derivatives_substep(
+        xi, r + dxi * dr_2 * 0.5, pr + dxi * dpr_2 * 0.5, q, dxi, dr,
+        r_max_plasma, dr_p, parabolic_coefficient,
+        a2, nabla_a2, b_t_0, r_fld, xi_fld,
+        a2_3, nabla_a2_3, b_t_0_3, b_t_3, psi_3, dr_psi_3, dxi_psi_3,
+        dr_3, dpr_3)
+    derivatives_substep(
+        xi, r + dxi * dr_3, pr + dxi * dpr_3, q, dxi, dr,
+        r_max_plasma, dr_p, parabolic_coefficient,
+        a2, nabla_a2, b_t_0, r_fld, xi_fld,
+        a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4,
+        dr_4, dpr_4)
 
     # Advance radial position and momentum.
-    apply_rk4(pp.r, dxi, *dr_arrays)
-    apply_rk4(pp.pr, dxi, *dpr_arrays)
+    apply_rk4(r, dxi, dr_1, dr_2, dr_3, dr_4)
+    apply_rk4(pr, dxi, dpr_1, dpr_2, dpr_3, dpr_4)
 
     # If a particle has crossed the axis, mirror it.
-    idx_neg = np.where(pp.r < 0.)
+    idx_neg = np.where(r < 0.)
     if idx_neg[0].size > 0:
-        pp.r[idx_neg] *= -1.
-        pp.pr[idx_neg] *= -1.
+        r[idx_neg] *= -1.
+        pr[idx_neg] *= -1.
 
 
-def derivatives_substep(i, pp, xi, a2, nabla_a2, b_theta_0, r_fld, xi_fld):
+@njit()
+def derivatives_substep(
+        xi, r, pr, q, dxi, dr, r_max_plasma, dr_p, parabolic_coefficient,
+        a2, nabla_a2, b_t_0, r_fld, xi_fld,
+        a2_i, nabla_a2_i, b_t_0_i, b_t_i, psi_i, dr_psi_i, dxi_psi_i,
+        dr_i, dpr_i):
     """Calculate r and pr derivatives at the i-th RK4 substep.
 
     The Runge-Kutta method of 4th order requires knowing the derivative (slope)
     of the variable to advance not only at the current location, but also at
     three other intermediate steps. This method takes care of calculating
-    the derivatives of r and pr at the 4 required substeps. This includes
+    the derivatives of r and pr at the 3 required substeps. This includes
     gathering and computing all the fields at the location of each particle,
     which are required to calculate the derivatives.
 
     Parameters
     ----------
-    i : int
-        Index of the RK4 substep (between 0 and 3).
-    pp : PlasmaParticles
-        The plasma particles being evolved.
     xi : float
-        Longitudinal position of the plasma slice at the beginning of the push.
-    a2 : ndarray
-        2D array with the square of the laser envelope in the r-z grid.
-    nabla_a2 : ndarray
-        2D array with the radial derivative of the square of the laser envelope
-        in the r-z grid.
-    b_theta_0 : ndarray
-        2D array with the azimuthal magnetic field of the electron beam(s)
-        in the r-z grid.
-    r_fld : ndarray
-        Array containing the radial position of the grid points.
-    xi_fld : ndarray
-        Array containing the longitudinal position of the grid points.
+        Current longitudinal position of the plasma slice.
+    r, pr, q : ndarray
+        Radial position, radial momentum and charge of the plasma particles.
+    dxi, dr : float
+        Grid spacing.
+    r_max_plasma : float
+        Maximum radial extent of the plasma
+    dr_p : float
+        Initial radial spacing between plasma particles.
+    parabolic_coefficient : float
+        Coefficient for the parabolic radial plasma profile.
+    a2, nabla_a2, b_t_0 : ndarray
+        Laser and beam source fields.
+    xi_fld, r_fld : ndarray
+        Grid coordinates
+    a2_i, ..., dxi_psi_i : ndarray
+        Arrays where the field values at the particle positions at substep i
+        will be stored.
+    dr_i, dpr_i : ndarray
+        Arrays that will contain the derivative of the radial position and of
+        the radial momentum of the particles at substep i.
     """
-    # Get arrays that contain the fields at the position of plasma particles.
-    # There is one set of arrays for each substep of the Runge-Kutta push.
-    (a2_pp, nabla_a2_pp, b_theta_0_pp, b_theta_pp,
-     psi_pp, dr_psi_pp, dxi_psi_pp) = pp.get_rk4_field_arrays(i)
 
-    # Get arrays that contain, or will contain, the derivatives of r and pr
-    # at each substep.
-    dr_arrays, dpr_arrays = pp.get_rk4_arrays()
+    # Check for particles with negative radial position and mirror them.
+    idx_neg = np.where(r < 0.)
+    if idx_neg[0].size > 0:
+        r[idx_neg] *= -1.
+        pr[idx_neg] *= -1.
 
-    # The first substep (at the initial location of the plasma slice) already
-    # has all the fields at the plasma particles (they were gathered/calculated
-    # in the main loop of the Baxevanis solver). For the other 3 substeps of
-    # the Runge-Kutta push, they still need to be obtained:
-    if i != 0:
-        dxi = xi_fld[1] - xi_fld[0]
-        dr = r_fld[1] - r_fld[0]
+    # Gather source terms at position of plasma particles.
+    gather_sources_qs_baxevanis(
+        a2, nabla_a2, b_t_0, xi_fld[0], xi_fld[-1],
+        r_fld[0], r_fld[-1], dxi, dr, r, xi, a2_i, nabla_a2_i,
+        b_t_0_i)
 
-        if i in [1, 2]:
-            mult = 0.5
-        else:
-            mult = 1
+    # Get sorted particle indices
+    idx = np.argsort(r)
 
-        r = pp.r + dxi * dr_arrays[i-1] * mult
-        pr = pp.pr + dxi * dpr_arrays[i-1] * mult
-        q = pp.q
-        xi = xi - dxi * mult
+    # Calculate wakefield potential and derivatives at plasma particles.
+    calculate_psi_and_derivatives_at_particles(
+        r, pr, q, idx, r_max_plasma, dr_p, parabolic_coefficient,
+        psi_i, dr_psi_i, dxi_psi_i)
 
-        # Check for particles with negative radial position and mirror them.
-        idx_neg = np.where(r < 0.)
-        if idx_neg[0].size > 0:
-            r[idx_neg] *= -1.
-            pr[idx_neg] *= -1.
+    # Calculate gamma of plasma particles
+    gamma = (
+        1. + pr ** 2 + a2_i + (1. + psi_i) ** 2) / (2. * (1. + psi_i))
 
-        # Gather source terms at position of plasma particles.
-        gather_sources_qs_baxevanis(
-            a2, nabla_a2, b_theta_0, xi_fld[0], xi_fld[-1],
-            r_fld[0], r_fld[-1], dxi, dr, pp.r, xi, a2_pp, nabla_a2_pp,
-            b_theta_0_pp)
-
-        # Get sorted particle indices
-        idx = np.argsort(r)
-
-        # Calculate wakefield potential and derivatives at plasma particles.
-        calculate_psi_and_derivatives_at_particles(
-            r, pr, q, idx, pp.r_max_plasma, pp.dr_p, pp.parabolic_coefficient,
-            psi_pp, dr_psi_pp, dxi_psi_pp)
-
-        # Calculate gamma of plasma particles
-        gamma = (
-            1. + pr ** 2 + a2_pp + (1. + psi_pp) ** 2) / (2. * (1. + psi_pp))
-
-        # Calculate azimuthal magnetic field from the plasma at the location of
-        # the plasma particles.
-        calculate_b_theta_at_particles(
-            r, pr, q, gamma, psi_pp, dr_psi_pp, dxi_psi_pp,
-            b_theta_0_pp, nabla_a2_pp, idx, pp.dr_p, b_theta_pp)
-    else:
-        r = pp.r
-        pr = pp.pr
-        gamma = pp.gamma
+    # Calculate azimuthal magnetic field from the plasma at the location of
+    # the plasma particles.
+    calculate_b_theta_at_particles(
+        r, pr, q, gamma, psi_i, dr_psi_i, dxi_psi_i,
+        b_t_0_i, nabla_a2_i, idx, dr_p, b_t_i)
 
     # Using the gathered/calculated fields, compute derivatives of r and pr
     # at the current slice.
-    dr_pp = dr_arrays[i]
-    dpr_pp = dpr_arrays[i]
     calculate_derivatives(
-        pr, gamma, b_theta_0_pp, nabla_a2_pp, b_theta_pp,
-        psi_pp, dr_psi_pp, dr_pp, dpr_pp
+        pr, gamma, b_t_0_i, nabla_a2_i, b_t_i,
+        psi_i, dr_psi_i, dr_i, dpr_i
     )
 
-    if i != 0:
-        # For particles which crossed the axis and were inverted, invert now
-        # back the sign of the derivatives.
-        if idx_neg[0].size > 0:
-            dr_pp[idx_neg] *= -1.
-            dpr_pp[idx_neg] *= -1.
+    # For particles which crossed the axis and were inverted, invert now
+    # back the sign of the derivatives.
+    if idx_neg[0].size > 0:
+        dr_i[idx_neg] *= -1.
+        dpr_i[idx_neg] *= -1.
 
 
 @njit()
 def calculate_derivatives(
-        pr, gamma, b_theta_0, nabla_a2, b_theta_bar, psi, dr_psi, dr, dpr):
+        pr, gamma, b_t_0, nabla_a2, b_t_bar, psi, dr_psi, dr, dpr):
     """
     Calculate the derivative of the radial position and the radial momentum
     of the plasma particles at the current slice.
@@ -171,13 +182,13 @@ def calculate_derivatives(
     pr, gamma : ndarray
         Arrays containing the radial momentum and Lorentz factor of the
         plasma particles.
-    b_theta_0 : ndarray
+    b_t_0 : ndarray
         Array containing the value of the azimuthal magnetic field from
         the beam distribution at the position of each plasma particle.
     nabla_a2 : ndarray
         Array containing the value of the gradient of the laser normalized
         vector potential at the position of each plasma particle.
-    b_theta_bar : ndarray
+    b_t_bar : ndarray
         Array containing the value of the azimuthal magnetic field from
         the plasma at the position of each plasma particle.
     psi, dr_psi : ndarray
@@ -191,8 +202,8 @@ def calculate_derivatives(
     for i in range(pr.shape[0]):
         psi_i = psi[i]
         dpr[i] = (gamma[i] * dr_psi[i] / (1. + psi_i)
-                  - b_theta_bar[i]
-                  - b_theta_0[i]
+                  - b_t_bar[i]
+                  - b_t_0[i]
                   - nabla_a2[i] / (2. * (1. + psi_i)))
         dr[i] = pr[i] / (1. + psi_i)
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -212,6 +212,7 @@ def evolve_plasma_and_calculate_fields(
         raise ValueError(
             "Plasma pusher '{}' not recognized.".format(plasma_pusher))
 
+
 @njit()
 def calculate_with_ab5(
         r_pp, pr_pp, pz_pp, gamma_pp, q_pp,
@@ -220,8 +221,7 @@ def calculate_with_ab5(
         a2, nabla_a2, b_t_0, psi, b_t_bar, rho, chi,
         xi_fld, r_fld, dxi, dr, n_xi, n_r,
         max_gamma, p_shape,
-        dr_1, dr_2, dr_3, dr_4, dr_5, dpr_1, dpr_2, dpr_3, dpr_4, dpr_5
-    ):
+        dr_1, dr_2, dr_3, dr_4, dr_5, dpr_1, dpr_2, dpr_3, dpr_4, dpr_5):
     """Calculate plasma evolution using the Adams-Bashforth pusher.
 
     Parameters
@@ -296,8 +296,7 @@ def calculate_with_rk4(
         a2_1, nabla_a2_1, b_t_0_1, b_t_1, psi_1, dr_psi_1, dxi_psi_1,
         a2_2, nabla_a2_2, b_t_0_2, b_t_2, psi_2, dr_psi_2, dxi_psi_2,
         a2_3, nabla_a2_3, b_t_0_3, b_t_3, psi_3, dr_psi_3, dxi_psi_3,
-        a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4
-    ):
+        a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4):
     """Calculate plasma evolution using the Adams-Bashforth pusher.
 
     Parameters
@@ -372,8 +371,7 @@ def calculate_and_deposit_plasma_column(
         a2_pp, nabla_a2_pp, b_t_0_pp, b_t_pp, psi_pp, dr_psi_pp, dxi_psi_pp,
         a2, nabla_a2, b_t_0, psi, b_t_bar, rho, chi,
         xi_fld, r_fld, dxi, dr, n_xi, n_r,
-        max_gamma, p_shape
-    ):
+        max_gamma, p_shape):
     """Calculate the fields at the current position of the plasma particles
     and calculate/deposit the azimuthal magnetic field from the plasma
     (b_t_bar), the wakefield potential (psi), the plasma charge density (rho)


### PR DESCRIPTION
This PR rewrites the main loop that pushes the plasma column along the simulation box such that it can be fully compiled with numba. This speeds up the wakefield calculation by up to ~40-50%.

In order to compile this loop, the plasma particle pusher and plasma particle deposition have also been rewritten in a way that can be fully compiled with numba.

Due to the larger amount of numba functions, the initial compile time has also increased to about ~25 s. It would be good to look now into numba caching options (#35)