### PR TITLE
Implement numba caching and custom decorators

### DIFF
--- a/wake_t/fields/analytical_field.py
+++ b/wake_t/fields/analytical_field.py
@@ -1,9 +1,9 @@
 """Contains the class used to define analytic fields."""
 
 import numpy as np
-from numba import njit
 
 from .base import Field
+from wake_t.utilities.numba import njit_serial
 
 
 class AnalyticalField(Field):
@@ -62,12 +62,12 @@ class AnalyticalField(Field):
             """Default field component."""
             pass
 
-        self.__e_x = njit()(e_x) if e_x is not None else no_field
-        self.__e_y = njit()(e_y) if e_y is not None else no_field
-        self.__e_z = njit()(e_z) if e_z is not None else no_field
-        self.__b_x = njit()(b_x) if b_x is not None else no_field
-        self.__b_y = njit()(b_y) if b_y is not None else no_field
-        self.__b_z = njit()(b_z) if b_z is not None else no_field
+        self.__e_x = njit_serial(e_x) if e_x is not None else no_field
+        self.__e_y = njit_serial(e_y) if e_y is not None else no_field
+        self.__e_z = njit_serial(e_z) if e_z is not None else no_field
+        self.__b_x = njit_serial(b_x) if b_x is not None else no_field
+        self.__b_y = njit_serial(b_y) if b_y is not None else no_field
+        self.__b_z = njit_serial(b_z) if b_z is not None else no_field
         self.constants = np.array(constants)
 
     def _pre_gather(self, x, y, z, t):

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -8,8 +8,9 @@ implemented in FBPIC (https://github.com/fbpic/fbpic).
 """
 
 import math
-from numba import njit
 import numpy as np
+
+from wake_t.utilities.numba import njit_serial
 
 
 def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
@@ -65,7 +66,7 @@ def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
         raise ValueError(err_string)
 
 
-@njit
+@njit_serial
 def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                    deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming linear particle shape. """
@@ -152,7 +153,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     return
 
 
-@njit
+@njit_serial
 def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                   deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming cubic particle shape. """

--- a/wake_t/particles/interpolation.py
+++ b/wake_t/particles/interpolation.py
@@ -11,10 +11,11 @@ shapes.
 
 import math
 import numpy as np
-from numba import njit, prange
+
+from wake_t.utilities.numba import njit_serial
 
 
-@njit()
+@njit_serial()
 def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     """
     Interpolate a 2D field defined on an r-z grid to the particle positions
@@ -92,7 +93,7 @@ def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     return fld_part
 
 
-@njit()
+@njit_serial()
 def gather_main_fields_cyl_linear(
         er, ez, bt, z_min, z_max, r_min, r_max, dz, dr, x, y, z,
         ex_part, ey_part, ez_part, bx_part, by_part, bz_part):
@@ -130,7 +131,7 @@ def gather_main_fields_cyl_linear(
     n_part = x.shape[0]
 
     # Iterate over all particles.
-    for i in prange(n_part):
+    for i in range(n_part):
 
         # Get particle position.
         x_i = x[i]
@@ -207,7 +208,7 @@ def gather_main_fields_cyl_linear(
             by_part[i] += bt_i * x_i * inv_r_i
 
 
-@njit()
+@njit_serial()
 def gather_sources_qs_baxevanis(fld_1, fld_2, fld_3, z_min, z_max, r_min,
                                 r_max, dz, dr, r, z, fld_1_pp, fld_2_pp,
                                 fld_3_pp):
@@ -251,7 +252,7 @@ def gather_sources_qs_baxevanis(fld_1, fld_2, fld_3, z_min, z_max, r_min,
     """
 
     # Iterate over all particles.
-    for i in prange(r.shape[0]):
+    for i in range(r.shape[0]):
 
         # Get particle position.
         z_i = z

--- a/wake_t/particles/push/boris_pusher.py
+++ b/wake_t/particles/push/boris_pusher.py
@@ -4,9 +4,9 @@ Contains the Boris pusher
 Authors: Jorge Ordóñez Carrasco, Ángel Ferran Pousa.
 """
 import numpy as np
-from numba import njit
 import scipy.constants as ct
 
+from wake_t.utilities.numba import njit_serial
 from wake_t.fields.gather import gather_fields
 
 
@@ -39,7 +39,7 @@ def apply_boris_pusher(bunch, fields, t, dt):
         bunch.x, bunch.y, bunch.xi, bunch.px, bunch.py, bunch.pz, dt)
 
 
-@njit()
+@njit_serial()
 def apply_half_position_push(x, y, xi, px, py, pz, dt):
     for i in range(x.shape[0]):
         # Get particle momentum
@@ -55,7 +55,7 @@ def apply_half_position_push(x, y, xi, px, py, pz, dt):
         xi[i] += 0.5 * (pz_i * c_over_gamma_i - ct.c) * dt
 
 
-@njit()
+@njit_serial()
 def push_momentum(px, py, pz, ex, ey, ez, bx, by, bz, dt):
     k = -ct.e*dt/(ct.m_e*2*ct.c)
 

--- a/wake_t/particles/push/runge_kutta_4.py
+++ b/wake_t/particles/push/runge_kutta_4.py
@@ -1,9 +1,9 @@
 """ Contains the Runge-Kutta pusher of order 4 """
 
-from numba import njit, prange
 import math
 import scipy.constants as ct
 
+from wake_t.utilities.numba import njit_serial
 from wake_t.fields.gather import gather_fields
 
 
@@ -117,40 +117,40 @@ def apply_rk4_pusher(bunch, fields, t, dt):
     apply_push(bunch.pz, dt, dpz)
 
 
-@njit()
+@njit_serial()
 def initialize_coord(x, x_0):
-    for i in prange(x.shape[0]):
+    for i in range(x.shape[0]):
         x[i] = x_0[i]
 
 
-@njit()
+@njit_serial()
 def update_coord(x, x_0, dt, k_x, fac):
-    for i in prange(x.shape[0]):
+    for i in range(x.shape[0]):
         x[i] = x_0[i] + dt * k_x[i] * fac
 
 
-@njit()
+@njit_serial()
 def initialize_push(dx, k_x, fac):
-    for i in prange(dx.shape[0]):
+    for i in range(dx.shape[0]):
         dx[i] = k_x[i] * fac
 
 
-@njit()
+@njit_serial()
 def update_push(dx, k_x, fac):
-    for i in prange(dx.shape[0]):
+    for i in range(dx.shape[0]):
         dx[i] += k_x[i] * fac
 
 
-@njit()
+@njit_serial()
 def apply_push(x, dt, dx):
-    for i in prange(x.shape[0]):
+    for i in range(x.shape[0]):
         x[i] += dt * dx[i]
 
 
-@njit(fastmath=True, error_model='numpy')
+@njit_serial(fastmath=True, error_model='numpy')
 def calculate_k(k_x, k_y, k_xi, k_px, k_py, k_pz,
                 q_over_mc, px, py, pz, ex, ey, ez, bx, by, bz):
-    for i in prange(k_x.shape[0]):
+    for i in range(k_x.shape[0]):
         px_i = px[i]
         py_i = py[i]
         pz_i = pz[i]

--- a/wake_t/physics_models/laser/envelope_solver.py
+++ b/wake_t/physics_models/laser/envelope_solver.py
@@ -7,11 +7,12 @@ Authors: Wilbert den Hertog, Ángel Ferran Pousa, Carlo Benedetti
 """
 
 import numpy as np
-from numba import njit
 import scipy.constants as ct
 
+from wake_t.utilities.numba import njit_serial
 
-@njit()
+
+@njit_serial()
 def L(sign, k, dr):
     """
     Calculation of L_k^{+-}. Change wrt Benedetti - 2018: in Wake-T we use cell
@@ -34,7 +35,7 @@ def L(sign, k, dr):
     return (1 + sign * 1 / (2 * (k + 0.5))) / dr ** 2
 
 
-@njit()
+@njit_serial()
 def C(sign, k, k0p, dt, dz, dr):
     """
     Calculate Equation (8) from Benedetti - 2018.
@@ -59,7 +60,7 @@ def C(sign, k, k0p, dt, dz, dr):
             - sign * 3 / 2 * 1 / (dt * dz) - 1 / dt ** 2)
 
 
-@njit()
+@njit_serial()
 def D(th, th1, th2, dz):
     """
     Calculate D in Equation (6) from Benedetti - 2018
@@ -95,7 +96,7 @@ def D(th, th1, th2, dz):
     return 1.5 * d_theta1 / dz - 0.5 * d_theta2 / dz
 
 
-@njit()
+@njit_serial()
 def rhs(a_old, a, a_new, chi, j, dz, k, dr, nr, dt, k0p, th, th1, th2):
     """
     The right-hand side of equation 7 in Benedetti, 2018.
@@ -148,7 +149,7 @@ def rhs(a_old, a, a_new, chi, j, dz, k, dr, nr, dt, k0p, th, th1, th2):
     return sol
 
 
-@njit()
+@njit_serial()
 def TDMA(a, b, c, d):
     """TriDiagonal Matrix Algorithm: solve a linear system Ax=b,
     where A is a tridiagonal matrix. Source:
@@ -185,7 +186,7 @@ def TDMA(a, b, c, d):
     return p
 
 
-@njit()
+@njit_serial()
 def evolve_envelope(a0, aold, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
                     start_outside_plasma=False):
     """

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -5,10 +5,11 @@ according to the paper by P. Baxevanis and G. Stupakov.
 """
 
 import numpy as np
-from numba import njit
+
+from wake_t.utilities.numba import njit_serial
 
 
-@njit()
+@njit_serial()
 def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
                                    b_theta_0, nabla_a2, idx, dr_p, b_theta_pp):
     """
@@ -85,7 +86,7 @@ def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
             b_theta_pp[i] = -3.
 
 
-@njit()
+@njit_serial()
 def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                       nabla_a2, idx, b_theta, k):
     """
@@ -152,7 +153,7 @@ def calculate_b_theta(r_fld, r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             b_theta_mesh[2+j] = a_i[i_p] * r_j + b_i[i_p] / r_j
 
 
-@njit()
+@njit_serial()
 def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                               nabla_a2, idx):
     """
@@ -265,7 +266,7 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
     return a_i, b_i, a_0
 
 
-@njit()
+@njit_serial()
 def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                               nabla_a2, idx):
     """

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/deposition.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/deposition.py
@@ -5,10 +5,11 @@ of plasma particles in a 2D r-z grid.
 """
 
 import math
-from numba import njit
+
+from wake_t.utilities.numba import njit_serial
 
 
-@njit()
+@njit_serial()
 def deposit_plasma_particles(z, r, w, z_min, r_min, nz, nr, dz, dr,
                              deposition_array, p_shape='cubic'):
     """
@@ -58,7 +59,7 @@ def deposit_plasma_particles(z, r, w, z_min, r_min, nz, nr, dz, dr,
             z, r, w, z_min, r_min, nz, nr, dz, dr, deposition_array)
 
 
-@njit
+@njit_serial
 def deposit_plasma_particles_linear(z, r, q, z_min, r_min, nz, nr, dz, dr,
                                     deposition_array):
     """ Calculate charge distribution assuming linear particle shape. """
@@ -115,7 +116,7 @@ def deposit_plasma_particles_linear(z, r, q, z_min, r_min, nz, nr, dz, dr,
             deposition_array[iz_cell + 1, ir_cell + 1] += zsl_1 * rsl_1 * w_i
 
 
-@njit
+@njit_serial
 def deposit_plasma_particles_cubic(z, r, q, z_min, r_min, nz, nr, dz, dr,
                                    deposition_array):
     """ Calculate charge distribution assuming cubic particle shape. """

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/ab5.py
@@ -2,10 +2,11 @@
 
 
 import numpy as np
-from numba import njit
+
+from wake_t.utilities.numba import njit_serial
 
 
-@njit()
+@njit_serial()
 def evolve_plasma_ab5(
         dxi, r, pr, gamma,
         nabla_a2_pp, b_theta_0_pp, b_theta_pp, psi_pp, dr_psi_pp,
@@ -71,7 +72,7 @@ def evolve_plasma_ab5(
         dpr_5[idx_neg] *= -1.
 
 
-@njit()
+@njit_serial()
 def calculate_derivatives(
         pr, gamma, b_theta_0, nabla_a2, b_theta_bar, psi, dr_psi, dr, dpr):
     """
@@ -109,7 +110,7 @@ def calculate_derivatives(
         dr[i] = pr[i] / (1. + psi_i)
 
 
-@njit()
+@njit_serial()
 def apply_ab5(x, dt, dx_1, dx_2, dx_3, dx_4, dx_5):
     """Apply the Adams-Bashforth method of 5th order to evolve `x`.
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/plasma_push/rk4.py
@@ -1,12 +1,12 @@
 import numpy as np
-from numba import njit
 
+from wake_t.utilities.numba import njit_serial
 from wake_t.particles.interpolation import gather_sources_qs_baxevanis
 from ..psi_and_derivatives import calculate_psi_and_derivatives_at_particles
 from ..b_theta import calculate_b_theta_at_particles
 
 
-@njit()
+@njit_serial()
 def evolve_plasma_rk4(
         dxi, dr, xi, r, pr, gamma, q, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
@@ -85,7 +85,7 @@ def evolve_plasma_rk4(
         pr[idx_neg] *= -1.
 
 
-@njit()
+@njit_serial()
 def derivatives_substep(
         xi, r, pr, q, dxi, dr, r_max_plasma, dr_p, pc,
         a2, nabla_a2, b_t_0, r_fld, xi_fld,
@@ -170,7 +170,7 @@ def derivatives_substep(
         dpr_i[idx_neg] *= -1.
 
 
-@njit()
+@njit_serial()
 def calculate_derivatives(
         pr, gamma, b_t_0, nabla_a2, b_t_bar, psi, dr_psi, dr, dpr):
     """
@@ -208,7 +208,7 @@ def calculate_derivatives(
         dr[i] = pr[i] / (1. + psi_i)
 
 
-@njit()
+@njit_serial()
 def apply_rk4(x, dt, kx_1, kx_2, kx_3, kx_4):
     """Apply the Runge-Kutta method of 4th order to evolve `x`
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/psi_and_derivatives.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/psi_and_derivatives.py
@@ -5,10 +5,11 @@ according to the paper by P. Baxevanis and G. Stupakov.
 """
 
 import numpy as np
-from numba import njit
+
+from wake_t.utilities.numba import njit_serial
 
 
-@njit()
+@njit_serial()
 def calculate_psi_and_derivatives_at_particles(
         r, pr, q, idx, r_max, dr_p, pc, psi_pp, dr_psi_pp, dxi_psi_pp):
     """
@@ -169,7 +170,7 @@ def calculate_psi_and_derivatives_at_particles(
             dxi_psi_pp[i] = -3.
 
 
-@njit()
+@njit_serial()
 def calculate_psi(r_fld, r, q, idx, r_max, pc, psi, k):
     """
     Calculate the wakefield potential at the radial
@@ -254,7 +255,7 @@ def calculate_psi(r_fld, r, q, idx, r_max, pc, psi, k):
     psi_slice -= delta_psi_eq(r_furthest, sum_1, sum_2, r_max, pc)
 
 
-@njit()
+@njit_serial()
 def calculate_psi_and_derivatives(r_fld, r, pr, q):
     """
     Calculate the wakefield potential and its derivatives at the radial
@@ -342,7 +343,7 @@ def calculate_psi_and_derivatives(r_fld, r, pr, q):
     return psi, dr_psi, dxi_psi
 
 
-@njit()
+@njit_serial()
 def delta_psi_eq(r, sum_1, sum_2, r_max, pc):
     """ Adapted equation (29) from original paper. """
     delta_psi_elec = sum_1*np.log(r) - sum_2
@@ -356,7 +357,7 @@ def delta_psi_eq(r, sum_1, sum_2, r_max, pc):
     return delta_psi_elec - delta_psi_ion
 
 
-@njit()
+@njit_serial()
 def dr_psi_eq(r, sum_1, r_max, pc):
     """ Adapted equation (31) from original paper. """
     dr_psi_elec = sum_1 / r

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/solver.py
@@ -8,7 +8,6 @@ for the full details about this model.
 
 import numpy as np
 import scipy.constants as ct
-from numba import njit
 import aptools.plasma_accel.general_equations as ge
 
 from wake_t.particles.deposition import deposit_3d_distribution
@@ -21,6 +20,7 @@ from .psi_and_derivatives import (
     calculate_psi, calculate_psi_and_derivatives_at_particles)
 from .b_theta import calculate_b_theta, calculate_b_theta_at_particles
 from .plasma_particles import PlasmaParticles
+from wake_t.utilities.numba import njit_serial
 
 
 def calculate_wakefields(laser_a2, beam_part, r_max, xi_min, xi_max,
@@ -213,7 +213,7 @@ def evolve_plasma_and_calculate_fields(
             "Plasma pusher '{}' not recognized.".format(plasma_pusher))
 
 
-@njit()
+@njit_serial()
 def calculate_with_ab5(
         r_pp, pr_pp, pz_pp, gamma_pp, q_pp,
         r_max_plasma, dr_p, parabolic_coefficient,
@@ -285,7 +285,7 @@ def calculate_with_ab5(
                 dpr_1, dpr_2, dpr_3, dpr_4, dpr_5)
 
 
-@njit()
+@njit_serial()
 def calculate_with_rk4(
         r_pp, pr_pp, pz_pp, gamma_pp, q_pp,
         r_max_plasma, dr_p, parabolic_coefficient,
@@ -364,7 +364,7 @@ def calculate_with_rk4(
                 a2_4, nabla_a2_4, b_t_0_4, b_t_4, psi_4, dr_psi_4, dxi_psi_4)
 
 
-@njit()
+@njit_serial()
 def calculate_and_deposit_plasma_column(
         i, xi, r_pp, pr_pp, pz_pp, gamma_pp, q_pp,
         r_max_plasma, dr_p, parabolic_coefficient,
@@ -458,7 +458,7 @@ def calculate_and_deposit_plasma_column(
                              dxi, dr, chi, p_shape=p_shape)
 
 
-@njit
+@njit_serial
 def update_gamma_and_pz(gamma, pz, pr, a2, psi):
     """
     Update the gamma factor and longitudinal momentum of the plasma particles.

--- a/wake_t/utilities/numba.py
+++ b/wake_t/utilities/numba.py
@@ -1,0 +1,22 @@
+"""This module contains custom definitions of the numba decorators."""
+
+import os
+from numba import njit
+
+
+# Check if the environment variable WAKET_DISABLE_CACHING is set to 1
+# and in that case, disable caching
+caching = True
+if 'WAKET_DISABLE_CACHING' in os.environ:
+    if int(os.environ['WAKET_DISABLE_CACHING']) == 1:
+        caching = False
+
+
+# Define custom njit decorator for serial methods.
+def njit_serial(*args, **kwargs):
+    return njit(*args, cache=caching, **kwargs)
+
+
+# Define custom njit decorator for parallel methods.
+def njit_parallel(*args, **kwargs):
+    return njit(*args, cache=caching, parallel=True, **kwargs)


### PR DESCRIPTION
This PR enables caching numba methods so that they do not need to be compiled every time the code is run. Similar to FBPIC, the caching can be disabled by setting the environment variable `WAKET_DISABLE_CACHING=1`.

Two custom `njit` decorators have been defined: `njit_serial` and `njit_parallel` (currently unused) to compile methods that should run in serial or that can run in parallel.