### PR TITLE
Improve openPMD diagnostics

### DIFF
--- a/tests/test_custom_blowout.py
+++ b/tests/test_custom_blowout.py
@@ -46,7 +46,7 @@ def test_custom_blowout_wakefield(make_plots=False):
 
     bunch_params = analyze_bunch(bunch)
     rel_ene_sp = bunch_params['rel_ene_spread']
-    assert approx(rel_ene_sp, rel=1e-10) == 0.21192531095086517
+    assert approx(rel_ene_sp, rel=1e-10) == 0.21192488237458038
 
     if make_plots:
         # Analyze bunch evolution.

--- a/tests/test_ramps.py
+++ b/tests/test_ramps.py
@@ -33,7 +33,7 @@ def test_downramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.009756658297049697
+    assert beta_x == 0.0097576829330571
 
 
 def test_upramp():
@@ -64,7 +64,7 @@ def test_upramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.0007642922463413662
+    assert beta_x == 0.0007641796148894149
 
 
 if __name__ == '__main__':

--- a/tests/test_simple_blowout.py
+++ b/tests/test_simple_blowout.py
@@ -45,7 +45,7 @@ def test_simple_blowout_wakefield(make_plots=False):
 
     bunch_params = analyze_bunch(bunch)
     rel_ene_sp = bunch_params['rel_ene_spread']
-    assert approx(rel_ene_sp, rel=1e-10) == 0.36376504595288617
+    assert approx(rel_ene_sp, rel=1e-10) == 0.3637648484576557
 
     if make_plots:
         # Analyze bunch evolution.

--- a/wake_t/diagnostics/openpmd_diag.py
+++ b/wake_t/diagnostics/openpmd_diag.py
@@ -92,7 +92,7 @@ class OpenPMDDiagnostics():
 
         # Write particle diagnostics.
         for species in species_list:
-            diag_data = species.get_openpmd_diagnostics_data()
+            diag_data = species.get_openpmd_diagnostics_data(it.time)
             self._write_species(it, diag_data)
 
         # Write field diagnostics.

--- a/wake_t/diagnostics/openpmd_diag.py
+++ b/wake_t/diagnostics/openpmd_diag.py
@@ -265,26 +265,32 @@ class OpenPMDDiagnostics():
                 fld[SCALAR].set_attribute(
                     'position', wf_data[field]['position'])
 
-            if field in ['E', 'W']:
+            if field == 'E':
                 fld.unit_dimension = {
                     Unit_Dimension.L: 1,
                     Unit_Dimension.M: 1,
                     Unit_Dimension.T: -3,
                     Unit_Dimension.I: -1
-                    }
+                }
+            if field == 'B':
+                fld.unit_dimension = {
+                    Unit_Dimension.M: 1,
+                    Unit_Dimension.T: -2,
+                    Unit_Dimension.I: -1
+                }
             elif field in ['rho', 'chi']:
                 fld.unit_dimension = {
                     Unit_Dimension.L: -3,
                     Unit_Dimension.T: 1,
                     Unit_Dimension.I: 1
-                    }
+                }
             elif field == 'a':
                 fld.unit_dimension = {
                     Unit_Dimension.L: 1,
                     Unit_Dimension.M: 1,
                     Unit_Dimension.T: -2,
                     Unit_Dimension.I: -1
-                    }
+                }
 
             # Set geometry to thetaMode until cylindrical geometry is
             # properly defined in the openPMD standard.

--- a/wake_t/diagnostics/openpmd_diag.py
+++ b/wake_t/diagnostics/openpmd_diag.py
@@ -272,7 +272,7 @@ class OpenPMDDiagnostics():
                     Unit_Dimension.T: -3,
                     Unit_Dimension.I: -1
                 }
-            if field == 'B':
+            elif field == 'B':
                 fld.unit_dimension = {
                     Unit_Dimension.M: 1,
                     Unit_Dimension.T: -2,

--- a/wake_t/particles/particle_bunch.py
+++ b/wake_t/particles/particle_bunch.py
@@ -273,7 +273,7 @@ class ParticleBunch():
         dxi = xi_c - current_xi_c
         self.xi += dxi
 
-    def get_openpmd_diagnostics_data(self):
+    def get_openpmd_diagnostics_data(self, global_time):
         """
         Returns a dictionary with the necessary data to write the openPMD
         diagnostics of the particle bunch.
@@ -290,7 +290,7 @@ class ParticleBunch():
             'q': -ct.e,
             'm': ct.m_e,
             'name': self.name,
-            'z_off': self.prop_distance
+            'z_off': global_time * ct.c
         }
         return diag_dict
 

--- a/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
@@ -180,15 +180,18 @@ class NonLinearColdFluidWakefield(NumericalField):
         # Cell-centered in 'r' and node centered in 'z'.
         fld_position = [0.5, 0.]
         fld_names = ['E', 'B', 'rho']
-        fld_comps = [['r', 'z'], ['t'], None]
+        fld_comps = [['r', 't', 'z'], ['r', 't', 'z'], None]
         # Need to make sure it is a contiguous array to prevent incorrect
         # openPMD output.
         fld_arrays = [
             [np.ascontiguousarray(self.E_r.T),
+             np.zeros((self.n_r, self.n_xi)),
              np.ascontiguousarray(self.E_z.T)],
-            [np.ascontiguousarray(self.B_t.T)],
+            [np.zeros((self.n_r, self.n_xi)),
+             np.ascontiguousarray(self.B_t.T),
+             np.zeros((self.n_r, self.n_xi))],
             [np.ascontiguousarray(self.n_fl.T) * self.current_n_p * (-ct.e)]
-            ]
+        ]
         if self.laser is not None:
             fld_names += ['a_mod', 'a_phase']
             fld_comps += [None, None]

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -116,13 +116,16 @@ class Quasistatic2DWakefield(NumericalField):
         # Cell-centered in 'r' and node centered in 'z'.
         fld_position = [0.5, 0.]
         fld_names = ['E', 'B', 'rho']
-        fld_comps = [['r', 'z'], ['t'], None]
+        fld_comps = [['r', 't', 'z'], ['r', 't', 'z'], None]
         fld_arrays = [
             [np.ascontiguousarray(self.E_r.T[2:-2, 2:-2]),
+             np.zeros((self.n_r, self.n_xi)),
              np.ascontiguousarray(self.E_z.T[2:-2, 2:-2])],
-            [np.ascontiguousarray(self.B_t.T[2:-2, 2:-2])],
+            [np.zeros((self.n_r, self.n_xi)),
+             np.ascontiguousarray(self.B_t.T[2:-2, 2:-2]),
+             np.zeros((self.n_r, self.n_xi))],
             [np.ascontiguousarray(self.rho.T[2:-2, 2:-2]) * self.n_p * (-ct.e)]
-            ]
+        ]
         if self.laser is not None:
             fld_names += ['a_mod', 'a_phase']
             fld_comps += [None, None]

--- a/wake_t/tracking/tracker.py
+++ b/wake_t/tracking/tracker.py
@@ -154,22 +154,26 @@ class Tracker():
             obj_next = self.objects_to_track[i_next]
             dt_next = dt_objects[i_next]
             t_next = t_next_objects[i_next]
+            t_current = t_objects[i_next]
 
             # If the next time of the object is beyond `t_final`, the tracking
             # is finished.
             if np.float32(t_next) > np.float32(self.t_final):
                 break
 
+            # Advance tracking time.
+            self.t_tracking = t_next
+
             # If next object is a ParticleBunch, update it.
             if isinstance(obj_next, ParticleBunch):
                 obj_next.evolve(
-                    self.fields, self.t_tracking, dt_next, self.bunch_pusher)
+                    self.fields, t_current, dt_next, self.bunch_pusher)
                 # Update the time step if set to `'auto'`.
                 if obj_next in self.auto_dt_bunches:
                     dt_objects[i_next] = self.auto_dt_bunch_f(obj_next)
                 # Determine if this was the last push.
                 final_push = np.float32(t_next) == np.float32(self.t_final)
-                # Determine is next push brings the bunch beyond `t_final`.
+                # Determine if next push brings the bunch beyond `t_final`.
                 next_push_beyond_final_time = (
                     t_next + dt_objects[i_next] > self.t_final)
                 # Make sure the last push of the bunch advances it to exactly
@@ -187,9 +191,6 @@ class Tracker():
 
             # Advance current time of the update object.
             t_objects[i_next] += dt_next
-
-            # Advance tracking time.
-            self.t_tracking = t_next
 
             # Update progress bar.
             progress_bar.update(self.t_tracking*ct.c - progress_bar.n)


### PR DESCRIPTION
- Include all components of `E` and `B` (i.e., `r`, `t` and `z`) in the openPMD output, even if they are zero. This improves compatibility with post-processing tools such as the openPMD viewer.
- Set the correct units of the `B` field. Currently no units were set, as the diagnostics still expected the transverse wakefield `W` instead of `E` and `B`.
- In the `Tracker`, update the tracking time before updating the next object. This makes sure, for example, that the openPMD diagnostics have the correct updated time.
- In the `ParticleBunch`, use the current global time instead of `prop_distance` to calculate the `z` offset. This makes sure that the beam does not jitter in `z` in the openPMD diagnostics if the beam push and diagnostics do not occur at the same time.

In addition:
- Pass the correct current time of the bunch when pushing it.
- Update tests so that they pass after this fix.