### PR TITLE
Progress bar improvements

### DIFF
--- a/wake_t/tracking/progress_bar.py
+++ b/wake_t/tracking/progress_bar.py
@@ -1,6 +1,12 @@
 """Defines a progress bar to be used by the Tracker."""
 
+import warnings
+
 from tqdm import tqdm
+
+
+# Avoid showing clamping warnings from the progress bar.
+warnings.filterwarnings('ignore', '.*clamping.*', )
 
 
 def get_progress_bar(description, total_length):

--- a/wake_t/tracking/progress_bar.py
+++ b/wake_t/tracking/progress_bar.py
@@ -1,5 +1,6 @@
 """Defines a progress bar to be used by the Tracker."""
 
+import sys
 import warnings
 
 from tqdm import tqdm
@@ -29,6 +30,7 @@ def get_progress_bar(description, total_length):
         desc=description,
         total=total_length,
         unit='m',
-        bar_format=l_bar + "{bar}" + r_bar
+        bar_format=l_bar + "{bar}" + r_bar,
+        file=sys.stdout
     )
     return progress_bar


### PR DESCRIPTION
Fixes two issues with the new progress bar:
- The common clamping warnings (probably caused by rounding errors) are no longer displayed.
- The progress bar output is now directed to `sys.stdout`, as expected.