### PR TITLE
Enable laser envelope solver subcycling

### DIFF
--- a/tests/test_laser_envelope_model.py
+++ b/tests/test_laser_envelope_model.py
@@ -77,7 +77,7 @@ def test_gaussian_laser_in_vacuum(plot=False):
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)
-    assert_almost_equal(np.sum(a_mod), 7500.380569504027, decimal=10)
+    assert_almost_equal(np.sum(a_mod), 7500.380279033873, decimal=10)
 
     # Make plots.
     if plot:

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -153,6 +153,11 @@ class PlasmaStage():
             using a laser envelope model. If False, the pulse envelope stays
             unchanged throughout the computation.
 
+        laser_envelope_substeps : int
+            Number of substeps of the laser envelope solver per `dz_fields`.
+            The time step of the envelope solver is therefore
+            `dz_fields / c / laser_envelope_substeps`.
+
         r_max : float
             Maximum radial position up to which plasma wakefield will be
             calculated.

--- a/wake_t/physics_models/laser/envelope_solver.py
+++ b/wake_t/physics_models/laser/envelope_solver.py
@@ -229,10 +229,6 @@ def evolve_envelope(a0, aold, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
     a_old = np.zeros((nz + 2, nr), dtype=np.complex128)
     a = np.zeros((nz + 2, nr), dtype=np.complex128)
 
-    # a_new is a 2 x nr array to store new values of a. a_new[0] = a_new[j+1]
-    # and a_new[1] = a_new[j+2].
-    a_new = np.zeros((2, nr), dtype=np.complex128)
-
     # Declaration of the 4 vectors used for solving the tridiagonal system.
     d_upper = np.zeros(nr - 1, dtype=np.complex128)
     d_lower = np.zeros(nr - 1, dtype=np.complex128)
@@ -249,6 +245,10 @@ def evolve_envelope(a0, aold, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
     k0p = k0 / kp
 
     for n in range(0, nt):
+        # a_new is a 2 x nr array to store new values of a.
+        # a_new[0] is equivalent to a_new[j+1] and a_new[1] to a_new[j+2].
+        a_new = np.zeros((2, nr), dtype=np.complex128)
+
         # Getting the phases of the envelope at the radius.
         phases = np.angle(a[:, 0])
 

--- a/wake_t/physics_models/laser/envelope_solver.py
+++ b/wake_t/physics_models/laser/envelope_solver.py
@@ -286,5 +286,5 @@ def evolve_envelope(a0, aold, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
         # When the left of the computational domain is reached, paste the last
         # few values in the a_old and a arrays.
         a_old[0:2] = a[0:2]
-        a[0] = a_new[0]
+        a[0:2] = a_new
     return a_old, a

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -62,6 +62,9 @@ class LaserPulse():
             every time `evolve` is called. All these time steps are therefore
             computed using the same `chi`.
         """
+        if nt < 1:
+            raise ValueError(
+                'Number of laser envelope substeps cannot be smaller than 1.')
         solver_params = {
             'zmin': xi_min,
             'zmax': xi_max,

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -128,7 +128,7 @@ class LaserPulse():
 
         # Update arrays and step count.
         self.a_env_old[:] = a_env_old[0: -2]
-        self.a_env = a_env[0: -2]
+        self.a_env[:] = a_env[0: -2]
         self.n_steps += 1
 
     def get_group_velocity(self, n_p):

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -11,13 +11,14 @@ from wake_t.fields.numerical_field import NumericalField
 class Quasistatic2DWakefield(NumericalField):
 
     def __init__(self, density_function, laser=None, laser_evolution=True,
-                 r_max=None, xi_min=None, xi_max=None, n_r=100,
-                 n_xi=100, ppc=2, dz_fields=None, r_max_plasma=None,
-                 parabolic_coefficient=0., p_shape='cubic', max_gamma=10,
-                 plasma_pusher='rk4'):
+                 laser_envelope_substeps=1, r_max=None, xi_min=None,
+                 xi_max=None, n_r=100, n_xi=100, ppc=2, dz_fields=None,
+                 r_max_plasma=None, parabolic_coefficient=0., p_shape='cubic',
+                 max_gamma=10, plasma_pusher='rk4'):
         self.density_function = density_function
         self.laser = laser
         self.laser_evolution = laser_evolution
+        self.laser_envelope_substeps = laser_envelope_substeps
         self.r_max = r_max
         self.xi_min = xi_min
         self.xi_max = xi_max
@@ -44,7 +45,7 @@ class Quasistatic2DWakefield(NumericalField):
         if self.laser is not None:
             self.laser.set_envelope_solver_params(
                 self.xi_min, self.xi_max, self.r_max, self.n_xi, self.n_r,
-                self.dt_update)
+                self.dt_update, self.laser_envelope_substeps)
             self.laser.initialize_envelope()
 
     def _evolve_properties(self, bunches):


### PR DESCRIPTION
This PR allows the laser envelope solver to have a different (smaller) time step than the wakefield update period defined by `dz_fields`. It defines a new parameter `laser_envelope_substeps` that can be given as input to a `PlasmaStage` when using the `quasistatic_2d` solver. This parameter must be an integer >= 1 (by default, 1) so that the time step of the envelope solver is `dz_fields / c / laser_envelope_substeps`.

In additon, this PR fixes two small bugs in the envelope solver that only become noticeable when the laser pulse reaches the back of the simulation box.