### PR TITLE
Subgrid envelope

### DIFF
--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -158,6 +158,11 @@ class PlasmaStage():
             The time step of the envelope solver is therefore
             `dz_fields / c / laser_envelope_substeps`.
 
+        laser_envelope_subgrid : int
+            Number of substeps of the laser envelope solver per `dz`.
+            The number of grid points in `z` of the envelope solver is
+            `n_xi * laser_envelope_subgrid`
+
         r_max : float
             Maximum radial position up to which plasma wakefield will be
             calculated.

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -11,9 +11,9 @@ class RZWakefield(NumericalField):
     """Base class for plasma wakefields in r-z geometry"""
 
     def __init__(self, density_function, laser=None, laser_evolution=True,
-                 laser_envelope_substeps=1, r_max=None, xi_min=None,
-                 xi_max=None, n_r=100, n_xi=100, dz_fields=None,
-                 model_name=''):
+                 laser_envelope_substeps=1, laser_envelope_subgrid=1,
+                 r_max=None, xi_min=None, xi_max=None, n_r=100, n_xi=100,
+                 dz_fields=None, model_name=''):
         """Initialize wakefield.
 
         Parameters
@@ -31,6 +31,10 @@ class RZWakefield(NumericalField):
             Number of substeps of the laser envelope solver per `dz_fields`.
             The time step of the envelope solver is therefore
             `dz_fields / c / laser_envelope_substeps`.
+        laser_envelope_subgrid : int
+            Number of substeps of the laser envelope solver per `dz`.
+            The number of grid points in `z` of the envelope solver is
+            `n_xi * laser_envelope_subgrid`
         r_max : float
             Maximum radial position up to which plasma wakefield will be
             calculated.
@@ -63,6 +67,7 @@ class RZWakefield(NumericalField):
         self.laser = laser
         self.laser_evolution = laser_evolution
         self.laser_envelope_substeps = laser_envelope_substeps
+        self.laser_envelope_subgrid = laser_envelope_subgrid
         self.r_max = r_max
         self.xi_min = xi_min
         self.xi_max = xi_max
@@ -84,7 +89,8 @@ class RZWakefield(NumericalField):
         if self.laser is not None:
             self.laser.set_envelope_solver_params(
                 self.xi_min, self.xi_max, self.r_max, self.n_xi, self.n_r,
-                self.dt_update, self.laser_envelope_substeps)
+                self.dt_update, self.laser_envelope_substeps,
+                self.laser_envelope_subgrid)
             self.laser.initialize_envelope()
 
         # Initialize field arrays

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -138,7 +138,7 @@ class LaserPulse():
 
         # adapt chi in case of nsubgrid > 1
         if self.nsubgrid > 1:
-            chi = zoom(chi, zoom=(self.nsubgrid, 1))
+            chi = zoom(chi, zoom=(self.nsubgrid, 1), order=1)
 
         # Compute evolution.
         a_env_old, a_env = evolve_envelope(

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -11,6 +11,7 @@ Authors: Angel Ferran Pousa, Remi Lehe, Manuel Kirchen, Pierre Pelletier.
 import numpy as np
 import scipy.constants as ct
 from scipy.special import genlaguerre, binom
+from scipy.ndimage import zoom
 
 from .envelope_solver import evolve_envelope
 
@@ -137,11 +138,7 @@ class LaserPulse():
 
         # adapt chi in case of nsubgrid > 1
         if self.nsubgrid > 1:
-            chi_new = np.zeros((2 * chi.shape[0], chi.shape[1]))
-            chi_new[::2] = chi
-            chi_new[1:-1:2] = chi[:-1] + np.diff(chi, axis=0) / 2.0
-            chi_new[-1] = chi_new[-2]
-            chi = chi_new
+            chi = zoom(chi, zoom=(self.nsubgrid, 1))
 
         # Compute evolution.
         a_env_old, a_env = evolve_envelope(

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -117,7 +117,10 @@ class LaserPulse():
 
     def get_envelope(self):
         """Get the current laser envelope array."""
-        return self.a_env[::self.nsubgrid]
+        if self.nsubgrid > 1:
+            return self.a_env[::self.nsubgrid]
+        else:
+            return self.a_env
 
     def evolve(self, chi, n_p):
         """

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -33,13 +33,14 @@ class LaserPulse():
         self.solver_params = None
         self.init_outside_plasma = False
         self.n_steps = 0
+        self.nsubgrid = 1
 
     def __add__(self, pulse_2):
         """Overload the add operator to allow summing of laser pulses."""
         return SummedPulse(self, pulse_2)
 
     def set_envelope_solver_params(self, xi_min, xi_max, r_max, nz, nr, dt,
-                                   nt=1):
+                                   nt=1, nsubgrid=1):
         """
         Set the parameters for the laser envelope solver.
 
@@ -61,15 +62,25 @@ class LaserPulse():
             therefore dt/nt, so that the laser effectively advances by `dt`
             every time `evolve` is called. All these time steps are therefore
             computed using the same `chi`.
+        nsubgrid : int
+            Number of substeps of the laser envelope solver per `dz`.
+            The number of grid points in `z` of the envelope solver is
+            effectively `nz * nsubgrid`
+
         """
         if nt < 1:
             raise ValueError(
                 'Number of laser envelope substeps cannot be smaller than 1.')
+        if nsubgrid < 1:
+            raise ValueError(
+                'Number of laser envelope subgrid steps cannot be smaller than 1.')
+        else:
+            self.nsubgrid = nsubgrid
         solver_params = {
             'zmin': xi_min,
             'zmax': xi_max,
             'rmax': r_max,
-            'nz': nz,
+            'nz': nz * nsubgrid,
             'nr': nr,
             'nt': nt,
             'dt': dt / nt
@@ -105,7 +116,7 @@ class LaserPulse():
 
     def get_envelope(self):
         """Get the current laser envelope array."""
-        return self.a_env
+        return self.a_env[::self.nsubgrid]
 
     def evolve(self, chi, n_p):
         """
@@ -123,6 +134,14 @@ class LaserPulse():
 
         # Determine if laser starts evolution outside plasma.
         start_outside_plasma = (self.n_steps == 0 and self.init_outside_plasma)
+
+        # adapt chi in case of nsubgrid > 1
+        if self.nsubgrid > 1:
+            chi_new = np.zeros((2 * chi.shape[0], chi.shape[1]))
+            chi_new[::2] = chi
+            chi_new[1:-1:2] = chi[:-1] + np.diff(chi, axis=0) / 2.0
+            chi_new[-1] = chi_new[-2]
+            chi = chi_new
 
         # Compute evolution.
         a_env_old, a_env = evolve_envelope(

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -8,9 +8,10 @@ from wake_t.fields.rz_wakefield import RZWakefield
 class Quasistatic2DWakefield(RZWakefield):
 
     def __init__(self, density_function, laser=None, laser_evolution=True,
-                 laser_envelope_substeps=1, r_max=None, xi_min=None,
-                 xi_max=None, n_r=100, n_xi=100, ppc=2, dz_fields=None,
-                 r_max_plasma=None, parabolic_coefficient=0., p_shape='cubic',
+                 laser_envelope_substeps=1, laser_envelope_subgrid=1,
+                 r_max=None, xi_min=None, xi_max=None, n_r=100, n_xi=100,
+                 ppc=2, dz_fields=None, r_max_plasma=None,
+                 parabolic_coefficient=0., p_shape='cubic',
                  max_gamma=10, plasma_pusher='rk4'):
         self.ppc = ppc
         self.r_max_plasma = r_max_plasma
@@ -24,6 +25,7 @@ class Quasistatic2DWakefield(RZWakefield):
             laser=laser,
             laser_evolution=laser_evolution,
             laser_envelope_substeps=laser_envelope_substeps,
+            laser_envelope_subgrid=laser_envelope_subgrid,
             r_max=r_max,
             xi_min=xi_min,
             xi_max=xi_max,


### PR DESCRIPTION
Implements a basic envelope solver sub-grid in z direction.
To enable, just pass `laser_envelope_subgrid` > 1 to the `PlasmaStage` object. 
It will sub-divide the grid used by the envelope solver by a factor `laser_envelope_subgrid`. 
The number of grid points in `z` of the envelope solver is then `nz * laser_envelope_subgrid`.