### PR TITLE
Replace old Travis badge with GitHub actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wake-T: A fast tracking code for plasma accelerators.
-[![Build Status](https://travis-ci.org/AngelFP/Wake-T.svg?branch=master)](https://travis-ci.org/AngelFP/Wake-T)
+[![tests badge](https://github.com/AngelFP/Wake-T/actions/workflows/test-package.yml/badge.svg)](https://github.com/AngelFP/Wake-T/actions)
 [![Documentation Status](https://readthedocs.org/projects/wake-t/badge/?version=latest)](https://wake-t.readthedocs.io/en/latest/?badge=latest)
 [![CodeFactor](https://www.codefactor.io/repository/github/angelfp/wake-t/badge)](https://www.codefactor.io/repository/github/angelfp/wake-t)
 [![PyPI](https://img.shields.io/pypi/v/Wake-T)](https://pypi.org/project/Wake-T/)


### PR DESCRIPTION
The unit tests have been running on GitHub actions for quite a while now. This PR replaces the old Travis badge with the corresponding badge from GitHub actions.