### PR TITLE
Make use of complex envelope phase optional + allow `Field` instances as `wakefield_model`

### DIFF
--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -180,6 +180,11 @@ class PlasmaStage():
             both parameters. If one of them is not given, the resolution of
             the plasma grid with be used for that direction.
 
+        laser_envelope_use_phase : bool
+            Determines whether to take into account the terms related to the
+            longitudinal derivative of the complex phase in the envelope
+            solver.
+
         r_max : float
             Maximum radial position up to which plasma wakefield will be
             calculated.

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -6,6 +6,7 @@ import scipy.constants as ct
 import wake_t.physics_models.plasma_wakefields as wf
 from wake_t.diagnostics import OpenPMDDiagnostics
 from wake_t.tracking.tracker import Tracker
+from wake_t.fields.base import Field
 
 
 wakefield_models = {
@@ -35,7 +36,7 @@ class PlasmaStage():
         density : float
             Plasma density in units of m^{-3}.
 
-        wakefield_model : str
+        wakefield_model : str or Field
             Wakefield model to be used. Possible values are 'blowout',
             'custom_blowout', 'focusing_blowout', 'cold_fluid_1d' and
             'quasistatic_2d'. If `None`, no wakefields will be computed.
@@ -330,6 +331,8 @@ class PlasmaStage():
         """ Initialize and return corresponding wakefield model. """
         if model is None:
             return None
+        elif isinstance(model, Field):
+            return model
         elif model in wakefield_models:
             return wakefield_models[model](self.density, **model_params)
         else:

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -12,7 +12,7 @@ class RZWakefield(NumericalField):
 
     def __init__(self, density_function, laser=None, laser_evolution=True,
                  laser_envelope_substeps=1, laser_envelope_nxi=None,
-                 laser_envelope_nr=None,
+                 laser_envelope_nr=None, laser_envelope_use_phase=True,
                  r_max=None, xi_min=None, xi_max=None, n_r=100, n_xi=100,
                  dz_fields=None, model_name=''):
         """Initialize wakefield.
@@ -39,6 +39,10 @@ class RZWakefield(NumericalField):
             coarser) grid than the plasma wake. It is not necessary to specify
             both parameters. If one of them is not given, the resolution of
             the plasma grid with be used for that direction.
+        laser_envelope_use_phase : bool
+            Determines whether to take into account the terms related to the
+            longitudinal derivative of the complex phase in the envelope
+            solver.
         r_max : float
             Maximum radial position up to which plasma wakefield will be
             calculated.
@@ -73,6 +77,7 @@ class RZWakefield(NumericalField):
         self.laser_envelope_substeps = laser_envelope_substeps
         self.laser_envelope_nxi = laser_envelope_nxi
         self.laser_envelope_nr = laser_envelope_nr
+        self.laser_envelope_use_phase = laser_envelope_use_phase
         self.r_max = r_max
         self.xi_min = xi_min
         self.xi_max = xi_max

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -126,7 +126,7 @@ class RZWakefield(NumericalField):
         self.b_t[:] = 0.
         self._calculate_wakefield(bunches)
 
-    def _calculate_wakefield(bunches):
+    def _calculate_wakefield(self, bunches):
         """To be implemented by the subclasses."""
         raise NotImplementedError
 

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -100,8 +100,8 @@ class RZWakefield(NumericalField):
             self.laser.set_envelope_solver_params(
                 self.xi_min, self.xi_max, self.r_max, self.n_xi, self.n_r,
                 self.dt_update, self.laser_envelope_substeps,
-                self.laser_envelope_nxi,
-                self.laser_envelope_nr)
+                self.laser_envelope_nxi, self.laser_envelope_nr,
+                self.laser_envelope_use_phase)
             self.laser.initialize_envelope()
 
         # Initialize field arrays

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -39,7 +39,8 @@ class LaserPulse():
         return SummedPulse(self, pulse_2)
 
     def set_envelope_solver_params(self, xi_min, xi_max, r_max, nz, nr, dt,
-                                   nt=1, subgrid_nz=None, subgrid_nr=None):
+                                   nt=1, subgrid_nz=None, subgrid_nr=None,
+                                   use_phase=True):
         """
         Set the parameters for the laser envelope solver.
 
@@ -67,6 +68,10 @@ class LaserPulse():
             plasma grid (nz, nr). Linear interpolation is used to transform
             the plasma susceptibility into the laser envelope grid, and to
             transform the laser envelope into the plasma grid.
+        use_phase : bool
+            Determines whether to take into account the terms related to the
+            longitudinal derivative of the complex phase in the envelope
+            solver.
 
         """
         if nt < 1:
@@ -88,7 +93,8 @@ class LaserPulse():
             'nz': subgrid_nz if self.use_subgrid else nz,
             'nr': subgrid_nr if self.use_subgrid else nr,
             'nt': nt,
-            'dt': dt / nt
+            'dt': dt / nt,
+            'use_phase': use_phase
         }
         if self.a_env is not None and solver_params != self.solver_params:
             raise ValueError(

--- a/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_cold_fluid_1x3p.py
@@ -11,7 +11,8 @@ from wake_t.fields.rz_wakefield import RZWakefield
 class NonLinearColdFluidWakefield(RZWakefield):
     def __init__(self, density_function, laser=None, laser_evolution=True,
                  laser_envelope_substeps=1, laser_envelope_nxi=None,
-                 laser_envelope_nr=None, r_max=None, xi_min=None,
+                 laser_envelope_nr=None, laser_envelope_use_phase=True,
+                 r_max=None, xi_min=None,
                  xi_max=None, n_r=100, n_xi=100, dz_fields=None,
                  beam_wakefields=False, p_shape='linear'):
         self.beam_wakefields = beam_wakefields
@@ -23,6 +24,7 @@ class NonLinearColdFluidWakefield(RZWakefield):
             laser_envelope_substeps=laser_envelope_substeps,
             laser_envelope_nxi=laser_envelope_nxi,
             laser_envelope_nr=laser_envelope_nr,
+            laser_envelope_use_phase=laser_envelope_use_phase,
             r_max=r_max,
             xi_min=xi_min,
             xi_max=xi_max,

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/wakefield.py
@@ -9,7 +9,8 @@ class Quasistatic2DWakefield(RZWakefield):
 
     def __init__(self, density_function, laser=None, laser_evolution=True,
                  laser_envelope_substeps=1, laser_envelope_nxi=None,
-                 laser_envelope_nr=None, r_max=None, xi_min=None,
+                 laser_envelope_nr=None, laser_envelope_use_phase=True,
+                 r_max=None, xi_min=None,
                  xi_max=None, n_r=100, n_xi=100, ppc=2, dz_fields=None,
                  r_max_plasma=None, parabolic_coefficient=0., p_shape='cubic',
                  max_gamma=10, plasma_pusher='rk4'):
@@ -27,6 +28,7 @@ class Quasistatic2DWakefield(RZWakefield):
             laser_envelope_substeps=laser_envelope_substeps,
             laser_envelope_nxi=laser_envelope_nxi,
             laser_envelope_nr=laser_envelope_nr,
+            laser_envelope_use_phase=laser_envelope_use_phase,
             r_max=r_max,
             xi_min=xi_min,
             xi_max=xi_max,


### PR DESCRIPTION
New features:
- A new `laser_envelope_use_phase` parameter has been added. It controls whether the terms related to the longitudinal derivative of the complex envelope phase are taken into account in the laser envelope solver. This improves the stability of the solver in long simulations.
- An instance of `Field` is now accepted as a `wakefield_model` in any `PlasmaStage` class.

Bug fixes:
- Added missing `self` in `RZWakefield` class method.