### PR TITLE
Implement non centered envelope solver for laser initialization

### DIFF
--- a/tests/test_fluid_model.py
+++ b/tests/test_fluid_model.py
@@ -42,7 +42,7 @@ def test_fluid_model(plot=False):
 
     # Check final parameters.
     ene_sp = params_evolution['rel_ene_spread'][-1]
-    assert approx(ene_sp, rel=1e-10) == 0.02386347411720627
+    assert approx(ene_sp, rel=1e-10) == 0.024183646993930535
 
     # Quick plot of results.
     if plot:

--- a/tests/test_laser_envelope_model.py
+++ b/tests/test_laser_envelope_model.py
@@ -77,7 +77,7 @@ def test_gaussian_laser_in_vacuum(plot=False):
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)
-    assert_almost_equal(np.sum(a_mod), 7500.380279033873, decimal=10)
+    assert_almost_equal(np.sum(a_mod), 7500.380522059235, decimal=10)
 
     # Make plots.
     if plot:
@@ -175,7 +175,7 @@ def test_gaussian_laser_in_vacuum_with_subgrid(plot=False):
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)
-    assert_almost_equal(np.sum(a_mod), 7500.120030707864, decimal=10)
+    assert_almost_equal(np.sum(a_mod), 7500.120208299948, decimal=10)
 
     # Make plots.
     if plot:

--- a/wake_t/physics_models/laser/envelope_solver.py
+++ b/wake_t/physics_models/laser/envelope_solver.py
@@ -91,7 +91,7 @@ def evolve_envelope(
 
         # Getting the phase of the envelope on axis.
         if use_phase:
-            phases = np.angle(a[:, 0])         
+            phases = np.angle(a[:, 0])
 
         # Loop over z.
         for j in range(nz - 1, -1, -1):
@@ -119,11 +119,11 @@ def evolve_envelope(
                 rhs[k] = (
                     - 2 * inv_dt ** 2 * a[j, k]
                     - ((C_minus - chi[j, k] * 0.5 - 1j * inv_dt * D_jkn)
-                    * a_old[j, k])
+                       * a_old[j, k])
                     - (2 * np.exp(-1j * d_theta1) * inv_dzdt
-                    * (a_new_jp1[k] - a_old[j + 1, k]))
+                       * (a_new_jp1[k] - a_old[j + 1, k]))
                     + (0.5 * np.exp(-1j * (d_theta2 + d_theta1)) * inv_dzdt
-                    * (a_new_jp2[k] - a_old[j + 2, k]))
+                       * (a_new_jp2[k] - a_old[j + 2, k]))
                 )
                 if k > 0:
                     rhs[k] -= L_minus_over_2[k] * a_old[j, k - 1]

--- a/wake_t/physics_models/laser/envelope_solver_non_centered.py
+++ b/wake_t/physics_models/laser/envelope_solver_non_centered.py
@@ -1,0 +1,153 @@
+"""
+This module contains the envelope solver. This module is strongly based on the
+paper 'An accurate and efficient laser-envelope solver for the modeling of
+laser-plasma accelerators', written by C Benedetti et al in 2018.
+
+Authors: Wilbert den Hertog, Ángel Ferran Pousa, Carlo Benedetti
+"""
+
+import numpy as np
+import scipy.constants as ct
+
+from wake_t.utilities.numba import njit_serial
+from .tdma import TDMA
+
+
+@njit_serial(fastmath=True)
+def evolve_envelope_non_centered(
+        a, a_old, chi, k0, kp, zmin, zmax, nz, rmax, nr, dt, nt,
+        use_phase=True):
+    """
+    Solve the 2D envelope equation using a non-centered time discretization.
+    (\nabla_tr^2+2i*k0/kp*d/dt+2*d^2/(dzdt)-d^2/dt^2)â = chi*â
+
+    Parameters
+    ----------
+    a0 : array
+        Initial value for â at tau=0. Dimension: nz*nr.
+    aold : array
+        Initial value for â at tau=-1. Dimension: nz*nr.
+    chi : array
+        Arrays of the values of the susceptibility. Dimension nz*nr.
+    k0 : float
+        Laser wave number.
+    kp : float
+        Plasma skin depth.
+    zmin : float
+        Minimum value for zeta.
+    zmax : float
+        Maximum value for zeta.
+    nz : int
+        Number of grid points in zeta-direction.
+    rmax : float
+        Maximum value for rho (minimum value is always 0).
+    nr : int
+        Amount of points in the rho direction.
+    dt : float
+        Tau step size.
+    nt : int
+        Number of tau steps.
+    use_phase : bool
+        Determines whether to take into account the terms related to the
+        longitudinal derivative of the complex phase.
+
+    """
+    # Preallocate arrays. a_old and a include 2 ghost cells in the z direction.
+    rhs = np.empty(nr, dtype=np.complex128)
+
+    # Calculate step sizes.
+    dz = (zmax - zmin) * kp / (nz - 1)
+    dr = rmax * kp / nr
+    dt = dt * ct.c * kp
+
+    # Precalculate common fractions.
+    inv_dt = 1 / dt
+    inv_dr = 1 / dr
+    inv_dz = 1 / dz
+    inv_dzdt = inv_dt * inv_dz
+    k0_over_kp = k0 / kp
+
+    # Initialize phase difference
+    d_theta1 = 0.
+    d_theta2 = 0.
+
+    # Calculate C^+ and C^- [Eq. (8)].
+    C_minus = (-2. * inv_dr ** 2. * 0.5  - 2 * 1j * k0_over_kp * inv_dt
+               + 3 * inv_dzdt)
+    C_plus = (-2. * inv_dr ** 2. * 0.5  + 2 * 1j * k0_over_kp * inv_dt
+              - 3 * inv_dzdt)
+
+    # Calculate L^+ and L^-. Change wrt Benedetti - 2018: in Wake-T we use
+    # cell-centered nodes in the radial direction.
+    L_base = 1. / (2. * (np.arange(nr) + 0.5))
+    L_minus_over_2 = (1. - L_base) * inv_dr ** 2. * 0.5
+    L_plus_over_2 = (1. + L_base) * inv_dr ** 2. * 0.5
+
+    # Loop over time iterations.
+    for n in range(nt):
+        # a_new_jp1 is equivalent to a_new[j+1] and a_new_jp2 to a_new[j+2].
+        a_new_jp1 = np.zeros(nr, dtype=np.complex128)
+        a_new_jp2 = np.zeros(nr, dtype=np.complex128)
+
+        # Getting the phase of the envelope on axis.
+        if use_phase:
+            phases = np.angle(a[:, 0])
+
+        # Loop over z.
+        for j in range(nz - 1, -1, -1):
+
+            # Calculate phase differences between adjacent points.
+            if use_phase:
+                d_theta1 = phases[j + 1] - phases[j]
+                d_theta2 = phases[j + 2] - phases[j + 1]
+
+                # Prevent phase jumps bigger than 1.5*pi.
+                if d_theta1 < -1.5 * np.pi:
+                    d_theta1 += 2 * np.pi
+                if d_theta2 < -1.5 * np.pi:
+                    d_theta2 += 2 * np.pi
+                if d_theta1 > 1.5 * np.pi:
+                    d_theta1 -= 2 * np.pi
+                if d_theta2 > 1.5 * np.pi:
+                    d_theta2 -= 2 * np.pi
+
+            # Calculate D factor [Eq. (6)].
+            D_jkn = (1.5 * d_theta1 - 0.5 * d_theta2) * inv_dz
+
+            # Calculate right-hand side of Eq (7).
+            for k in range(nr):
+                rhs[k] = (
+                    - (C_minus - chi[j, k] * 0.5 - 2 * 1j * inv_dt * D_jkn)
+                    * a[j, k]
+                    - (4 * np.exp(-1j * d_theta1) * inv_dzdt
+                    * (a_new_jp1[k] - a[j + 1, k]))
+                    + (1 * np.exp(-1j * (d_theta2 + d_theta1)) * inv_dzdt
+                    * (a_new_jp2[k] - a[j + 2, k]))
+                )
+                if k > 0:
+                    rhs[k] -= L_minus_over_2[k] * a[j, k - 1]
+                if k + 1 < nr:
+                    rhs[k] -= L_plus_over_2[k] * a[j, k + 1]
+
+            # Calculate diagonals.
+            d_main = C_plus - chi[j] * 0.5 + 2 * 1j * inv_dt * D_jkn
+            d_upper = L_plus_over_2[:nr - 1]
+            d_lower = L_minus_over_2[1:nr]
+
+            # Update a_old and a at j+2 with the current values of a a_new.
+            a_old[j + 2] = a[j + 2]
+            a[j + 2] = a_new_jp2
+
+            # Shift a_new[j+1] to a_new[j+2] in preparation for the next
+            # iteration.
+            a_new_jp2[:] = a_new_jp1
+
+            # Compute a_new at the current j using the TDMA method and store
+            # result in a_new_jp1 to use it in the next iteration.
+            TDMA(d_lower, d_main, d_upper, rhs, a_new_jp1)
+
+        # When the left of the computational domain is reached, paste the last
+        # few values in the a_old and a arrays.
+        a_old[0:2] = a[0:2]
+        a[0] = a_new_jp1
+        a[1] = a_new_jp2

--- a/wake_t/physics_models/laser/envelope_solver_non_centered.py
+++ b/wake_t/physics_models/laser/envelope_solver_non_centered.py
@@ -1,7 +1,7 @@
 """
-This module contains the envelope solver. This module is strongly based on the
-paper 'An accurate and efficient laser-envelope solver for the modeling of
-laser-plasma accelerators', written by C Benedetti et al in 2018.
+This module contains a non-centered (in time) version of the envelope solver
+described in 'An accurate and efficient laser-envelope solver for the modeling
+of laser-plasma accelerators', written by C Benedetti et al in 2018.
 
 Authors: Wilbert den Hertog, Ángel Ferran Pousa, Carlo Benedetti
 """

--- a/wake_t/physics_models/laser/envelope_solver_non_centered.py
+++ b/wake_t/physics_models/laser/envelope_solver_non_centered.py
@@ -72,9 +72,9 @@ def evolve_envelope_non_centered(
     d_theta2 = 0.
 
     # Calculate C^+ and C^- [Eq. (8)].
-    C_minus = (-2. * inv_dr ** 2. * 0.5 - 2 * 1j * k0_over_kp * inv_dt
+    C_minus = (-2. * inv_dr ** 2. * 0.5 - 2j * k0_over_kp * inv_dt
                + 3 * inv_dzdt)
-    C_plus = (-2. * inv_dr ** 2. * 0.5 + 2 * 1j * k0_over_kp * inv_dt
+    C_plus = (-2. * inv_dr ** 2. * 0.5 + 2j * k0_over_kp * inv_dt
               - 3 * inv_dzdt)
 
     # Calculate L^+ and L^-. Change wrt Benedetti - 2018: in Wake-T we use
@@ -117,7 +117,7 @@ def evolve_envelope_non_centered(
             # Calculate right-hand side of Eq (7).
             for k in range(nr):
                 rhs[k] = (
-                    - (C_minus - chi[j, k] * 0.5 - 2 * 1j * inv_dt * D_jkn)
+                    - (C_minus - chi[j, k] * 0.5 - 2j * inv_dt * D_jkn)
                     * a[j, k]
                     - (4 * np.exp(-1j * d_theta1) * inv_dzdt
                        * (a_new_jp1[k] - a[j + 1, k]))
@@ -130,7 +130,7 @@ def evolve_envelope_non_centered(
                     rhs[k] -= L_plus_over_2[k] * a[j, k + 1]
 
             # Calculate diagonals.
-            d_main = C_plus - chi[j] * 0.5 + 2 * 1j * inv_dt * D_jkn
+            d_main = C_plus - chi[j] * 0.5 + 2j * inv_dt * D_jkn
             d_upper = L_plus_over_2[:nr - 1]
             d_lower = L_minus_over_2[1:nr]
 

--- a/wake_t/physics_models/laser/envelope_solver_non_centered.py
+++ b/wake_t/physics_models/laser/envelope_solver_non_centered.py
@@ -72,9 +72,9 @@ def evolve_envelope_non_centered(
     d_theta2 = 0.
 
     # Calculate C^+ and C^- [Eq. (8)].
-    C_minus = (-2. * inv_dr ** 2. * 0.5  - 2 * 1j * k0_over_kp * inv_dt
+    C_minus = (-2. * inv_dr ** 2. * 0.5 - 2 * 1j * k0_over_kp * inv_dt
                + 3 * inv_dzdt)
-    C_plus = (-2. * inv_dr ** 2. * 0.5  + 2 * 1j * k0_over_kp * inv_dt
+    C_plus = (-2. * inv_dr ** 2. * 0.5 + 2 * 1j * k0_over_kp * inv_dt
               - 3 * inv_dzdt)
 
     # Calculate L^+ and L^-. Change wrt Benedetti - 2018: in Wake-T we use
@@ -120,9 +120,9 @@ def evolve_envelope_non_centered(
                     - (C_minus - chi[j, k] * 0.5 - 2 * 1j * inv_dt * D_jkn)
                     * a[j, k]
                     - (4 * np.exp(-1j * d_theta1) * inv_dzdt
-                    * (a_new_jp1[k] - a[j + 1, k]))
+                       * (a_new_jp1[k] - a[j + 1, k]))
                     + (1 * np.exp(-1j * (d_theta2 + d_theta1)) * inv_dzdt
-                    * (a_new_jp2[k] - a[j + 2, k]))
+                       * (a_new_jp2[k] - a[j + 2, k]))
                 )
                 if k > 0:
                     rhs[k] -= L_minus_over_2[k] * a[j, k - 1]

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -116,7 +116,6 @@ class LaserPulse():
             r_max = self.solver_params['rmax']
             nz = self.solver_params['nz']
             nr = self.solver_params['nr']
-            dt = self.solver_params['dt']
             dr = r_max / nr
             z = np.linspace(z_min, z_max, nz)
             r = np.linspace(dr/2, r_max-dr/2, nr)

--- a/wake_t/physics_models/laser/tdma.py
+++ b/wake_t/physics_models/laser/tdma.py
@@ -1,0 +1,45 @@
+"""
+This module contais the tridiagonal matrix algorithm (TDMA) used by the laser
+envelope solver.
+
+Authors: Wilbert den Hertog, Ángel Ferran Pousa
+"""
+
+import numpy as np
+
+from wake_t.utilities.numba import njit_serial
+
+
+@njit_serial(fastmath=True)
+def TDMA(a, b, c, d, p):
+    """TriDiagonal Matrix Algorithm: solve a linear system Ax=b,
+    where A is a tridiagonal matrix. Source:
+    https://stackoverflow.com/questions/8733015/tridiagonal-matrix-algorithm-
+    tdma-aka-thomas-algorithm-using-python-with-nump
+
+    Parameters
+    ----------
+    a : array
+        Lower diagonal of A. Dimension: nr-1.
+    b : array
+        Main diagonal of A. Dimension: nr.
+    c : array
+        Upper diagonal of A. Dimension: nr-1.
+    d : array
+        Solution vector. Dimension: nr.
+
+    """
+    n = len(d)
+    w = np.empty(n - 1, dtype=np.complex128)
+    g = np.empty(n, dtype=np.complex128)
+
+    w[0] = c[0] / b[0]  # MAKE SURE THAT b[0]!=0
+    g[0] = d[0] / b[0]
+
+    for i in range(1, n - 1):
+        w[i] = c[i] / (b[i] - a[i - 1] * w[i - 1])
+    for i in range(1, n):
+        g[i] = (d[i] - a[i - 1] * g[i - 1]) / (b[i] - a[i - 1] * w[i - 1])
+    p[n - 1] = g[n - 1]
+    for i in range(n - 1, 0, -1):
+        p[i - 1] = g[i - 1] - w[i - 1] * p[i]


### PR DESCRIPTION
This PR implements a non-centered version of the laser envelope solver that does not require the envelope at `t = t_n -dt`. The time discretization used results in the following equation:
![image](https://user-images.githubusercontent.com/20479420/201657387-4026ef7c-59f8-469b-9f5c-92fc45f67410.png)

This solver is particularly useful to compute the first time step of the envelope evolution. It provides a much better initialization than the previous method that greatly minimizes the numerical issues associated with it.