### PR TITLE
Fix precision issue in calculate_ai_bi_from_axis and calculate_ai_bi_from_edge

### DIFF
--- a/tests/test_active_plasma_lens.py
+++ b/tests/test_active_plasma_lens.py
@@ -64,7 +64,7 @@ def test_active_plasma_lens_with_wakefields():
     # Analyze and check results.
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 77.32005041792752
+    assert approx(gamma_x, rel=1e-10) == 77.32004939154773
 
 
 if __name__ == '__main__':

--- a/tests/test_multibunch.py
+++ b/tests/test_multibunch.py
@@ -55,8 +55,8 @@ def test_multibunch_plasma_simulation(plot=False):
     # Assert final parameters are correct.
     final_energy_driver = driver_params['avg_ene'][-1]
     final_energy_witness = witness_params['avg_ene'][-1]
-    assert approx(final_energy_driver, rel=1e-10) == 1700.3283476837953
-    assert approx(final_energy_witness, rel=1e-10) == 627.3163042861495
+    assert approx(final_energy_driver, rel=1e-10) == 1700.33213311266
+    assert approx(final_energy_witness, rel=1e-10) == 636.3355022503769
 
     if plot:
         z = driver_params['prop_dist'] * 1e2

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -307,7 +307,7 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
 
         Then b_N can be determined by imposing b_0 = 0:
 
-            b_0 = K_1 * b_N + T_1 = 0 <=> b_N = - T_1 / K_1
+            b_0 = K_1 * (b_N - b_N_guess) + T_1 = 0 <=> b_N = - T_1 / K_1 + b_N_guess
 
     """
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -300,20 +300,29 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             K_old = K[i] * a_0_diff
             U_old = U[i] * a_0_diff
 
+            # Test if precision is lost in the sum T_old + K_old.
+            # 0.5 ruffly corresponds to one lost bit of precision.
+            # Also pass test if this is the first number of this iteration
+            # to avoid an infinite loop or if this is the last number
+            # to computer as that is zero by construction
             if (i_sort == i_start or i_sort == (n_part-1) or
                     abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
                     abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
-                # Calculate a_i and b_i as functions of a_0.
+                # Calculate a_i and b_i as functions of a_0_diff.
+                # Store the result in T and P 
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
             else:
+                # Stop this iteration, go to the next one
                 i_stop = i_sort
                 break
 
         if i_stop < n_part:
+            # Set T_im1 and T_im1 properly for the next iteration 
             T_im1 = T[idx[i_stop-1]]
             P_im1 = P[idx[i_stop-1]]
 
+        # Start the next iteration where this one stopped
         i_start = i_stop
 
     return T, P, a_0

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -68,7 +68,7 @@ def calculate_b_theta_at_particles(r, pr, q, gamma, psi, dr_psi, dxi_psi,
         if i_sort < n_part - 1:
             r_ip1 = r[idx[i_sort+1]]
         else:
-            r_ip1 = r[i] * dr_p / 2
+            r_ip1 = r[i] + dr_p / 2
         r_right = (r_i + r_ip1) / 2
         b_theta_right = a_i[i] * r_right + b_i[i] / r_right
 
@@ -318,22 +318,16 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
         n_part = r.shape[0]
 
         # Preallocate arrays
-        K = np.zeros(n_part+1)
-        U = np.zeros(n_part+1)
-        T = np.zeros(n_part+1)
-        P = np.zeros(n_part+1)
+        K = np.zeros(n_part)
+        U = np.zeros(n_part)
+        T = np.zeros(n_part)
+        P = np.zeros(n_part)
 
         # Initial conditions at i = N+1
         K_ip1 = 0.
         U_ip1 = 1.
         T_ip1 = 0.
         P_ip1 = b_N_guess
-        K[-1] = K_ip1
-        U[-1] = U_ip1
-        T[-1] = T_ip1
-        P[-1] = P_ip1
-
-        # Sort particles
 
         # Iterate over particles
         for i_sort in range(n_part):
@@ -375,10 +369,10 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             P_i = n_i * T_ip1 + o_i * P_ip1 - r_i * (
                     C_i - 0.5 * B_i * r_i + 0.25 * A_i * C_i * r_i)
 
-            K[i] = K_i
-            U[i] = U_i
-            T[i] = T_i
-            P[i] = P_i
+            K[i] = K_ip1
+            U[i] = U_ip1
+            T[i] = T_ip1
+            P[i] = P_ip1
 
             K_ip1 = K_i
             U_ip1 = U_i
@@ -391,13 +385,11 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
         a_i = K * b_N_m_guess + T
         b_i = U * b_N_m_guess + P
 
-        print(b_N_iter, "b_N:", b_N_m_guess + b_N_guess, "a_i ratio: ", a_i[idx[1]]/(K[idx[1]] * b_N_m_guess - T[idx[1]]), "b_i ratio", b_i[idx[1]]/(U[idx[1]] * b_N_m_guess - P[idx[1]]))
+        #print(b_N_iter, "b_N:", b_N_m_guess + b_N_guess, "a_i ratio: ", a_i[idx[1]]/(K[idx[1]] * b_N_m_guess - T[idx[1]]), "b_i ratio", b_i[idx[1]]/(U[idx[1]] * b_N_m_guess - P[idx[1]]))
 
         # Get a_0 (value on-axis) and make sure a_i and b_i only contain the values
         # at the plasma particles.
-        a_0 = a_i[idx[0]]
-        a_i = np.delete(a_i, idx[0])
-        b_i = np.delete(b_i, idx[0])
+        a_0 = K_ip1 * b_N_m_guess + T_ip1
 
         b_N_guess += b_N_m_guess
     return a_i, b_i, a_0

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -414,9 +414,9 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             K_old = K[i] * b_N_diff
             U_old = U[i] * b_N_diff
 
-            if i_sort == i_start or
+            if (i_sort == i_start or
                 abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
-                abs(P_old + U_old) >= 0.5 * abs(P_old - U_old):
+                abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
             else:

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -301,7 +301,7 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             U_old = U[i] * a_0_diff
 
             # Test if precision is lost in the sum T_old + K_old.
-            # 0.5 ruffly corresponds to one lost bit of precision.
+            # 0.5 roughly corresponds to one lost bit of precision.
             # Also pass test if this is the first number of this iteration
             # to avoid an infinite loop or if this is the last number
             # to computer as that is zero by construction

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -391,7 +391,7 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
         a_i = K * b_N_m_guess + T
         b_i = U * b_N_m_guess + P
 
-        #print(b_N_iter, "b_N:", b_N_m_guess + b_N_guess, "a_i ratio: ", a_i[1]/(K[1] * b_N_m_guess - T[1]), "b_i ratio", b_i[1]/(U[1] * b_N_m_guess - P[1]))
+        print(b_N_iter, "b_N:", b_N_m_guess + b_N_guess, "a_i ratio: ", a_i[idx[1]]/(K[idx[1]] * b_N_m_guess - T[idx[1]]), "b_i ratio", b_i[idx[1]]/(U[idx[1]] * b_N_m_guess - P[idx[1]]))
 
         # Get a_0 (value on-axis) and make sure a_i and b_i only contain the values
         # at the plasma particles.

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -301,8 +301,8 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             U_old = U[i] * a_0_diff
 
             if (i_sort == i_start or i_sort == (n_part-1) or
-            abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
-            abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
+                    abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
+                    abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 # Calculate a_i and b_i as functions of a_0.
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
@@ -468,8 +468,8 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             U_old = U[i] * b_N_diff
 
             if (i_sort == i_start or
-            abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
-            abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
+                    abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
+                    abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
             else:

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -309,7 +309,7 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                     abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
                     abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 # Calculate a_i and b_i as functions of a_0_diff.
-                # Store the result in T and P 
+                # Store the result in T and P
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
             else:
@@ -318,7 +318,7 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
                 break
 
         if i_stop < n_part:
-            # Set T_im1 and T_im1 properly for the next iteration 
+            # Set T_im1 and T_im1 properly for the next iteration
             T_im1 = T[idx[i_stop-1]]
             P_im1 = P[idx[i_stop-1]]
 

--- a/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
+++ b/wake_t/physics_models/plasma_wakefields/qs_rz_baxevanis/b_theta.py
@@ -301,8 +301,8 @@ def calculate_ai_bi_from_axis(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             U_old = U[i] * a_0_diff
 
             if (i_sort == i_start or i_sort == (n_part-1) or
-                abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
-                abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
+            abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
+            abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 # Calculate a_i and b_i as functions of a_0.
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
@@ -468,8 +468,8 @@ def calculate_ai_bi_from_edge(r, pr, q, gamma, psi, dr_psi, dxi_psi, b_theta_0,
             U_old = U[i] * b_N_diff
 
             if (i_sort == i_start or
-                abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
-                abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
+            abs(T_old + K_old) >= 0.5 * abs(T_old - K_old) and
+            abs(P_old + U_old) >= 0.5 * abs(P_old - U_old)):
                 T[i] = T_old + K_old
                 P[i] = P_old + U_old
             else:


### PR DESCRIPTION
Allow for multiple iterations of this function. The a_0 or b_N calculated serves as the initial guess of a_0 or b_N for the next iteration. This way the correction factors K and U become small.