### PR TITLE
Field element

### DIFF
--- a/examples/track_plasma_fluid.py
+++ b/examples/track_plasma_fluid.py
@@ -39,7 +39,7 @@ plasma = PlasmaStage(
 
 # Do tracking.
 opmd_diag = False  # Set to True to activate openPMD output.
-bunch_list = plasma.track(bunch, out_initial=True, opmd_diag=opmd_diag)
+bunch_list = plasma.track(bunch, opmd_diag=opmd_diag)
 
 
 # Analyze bunch evolution.

--- a/examples/track_plasma_qs2d.py
+++ b/examples/track_plasma_qs2d.py
@@ -42,7 +42,7 @@ plasma = PlasmaStage(
 
 # Do tracking.
 opmd_diag = False  # Set to True to activate openPMD output.
-bunch_list = plasma.track(bunch, out_initial=True, opmd_diag=opmd_diag)
+bunch_list = plasma.track(bunch, opmd_diag=opmd_diag)
 
 
 # Analyze bunch evolution.

--- a/tests/test_beamline.py
+++ b/tests/test_beamline.py
@@ -32,14 +32,12 @@ def test_single_element():
     # Track plasma.
     bunch_1 = deepcopy(bunch)
     out_dir_1 = os.path.join(output_folder, 'plasma_diags')
-    plasma.track(
-        bunch_1, out_initial=True, opmd_diag=True, diag_dir=out_dir_1)
+    plasma.track(bunch_1, opmd_diag=True, diag_dir=out_dir_1)
 
     # Track beamline.
     bunch_2 = deepcopy(bunch)
     out_dir_2 = os.path.join(output_folder, 'bl_diags')
-    bl.track(
-        bunch_2, out_initial=True, opmd_diag=True, diag_dir=out_dir_2)
+    bl.track(bunch_2, opmd_diag=True, diag_dir=out_dir_2)
 
     # Check that final beams are identical.
     assert_array_equal(bunch_2.x, bunch_1.x)
@@ -87,14 +85,14 @@ def test_multiple_element():
     out_dir_d1 = os.path.join(output_folder, 'd1_diags')
     out_dir_plasma = os.path.join(output_folder, 'plasma_diags')
     out_dir_d2 = os.path.join(output_folder, 'd2_diags')
-    d1.track(bunch_1, out_initial=True, opmd_diag=True, diag_dir=out_dir_d1)
+    d1.track(bunch_1, opmd_diag=True, diag_dir=out_dir_d1)
     plasma.track(bunch_1, opmd_diag=True, diag_dir=out_dir_plasma)
     d2.track(bunch_1, opmd_diag=True, diag_dir=out_dir_d2)
 
     # Track beamline.
     bunch_2 = deepcopy(bunch)
     out_dir_bl = os.path.join(output_folder, 'bl_diags')
-    bl.track(bunch_2, out_initial=True, opmd_diag=True, diag_dir=out_dir_bl)
+    bl.track(bunch_2, opmd_diag=True, diag_dir=out_dir_bl)
 
     # Check that final beams are identical.
     assert_array_equal(bunch_2.x, bunch_1.x)

--- a/tests/test_field_element.py
+++ b/tests/test_field_element.py
@@ -1,0 +1,64 @@
+import numpy as np
+import scipy.constants as ct
+from pytest import approx
+
+from wake_t.utilities.bunch_generation import get_gaussian_bunch_from_twiss
+from wake_t.fields.analytical_field import AnalyticalField
+from wake_t.beamline_elements import FieldElement
+from wake_t.diagnostics import analyze_bunch
+
+
+def b_x(x, y, z, t, bx, constants):
+    """B_x component."""
+    k = constants[0]
+    bx -= k * y
+
+
+def b_y(x, y, z, t, by, constants):
+    """B_y component."""
+    k = constants[0]
+    by += k * x
+
+
+def test_field_element_tracking():
+    """Test that tracking in a field element works as expected by tracking
+    a bunch through an analytical field (azimuthal magnetic field)"""
+    # Set numpy random seed to get reproducible results
+    np.random.seed(1)
+
+    # Define field.
+    b_theta = AnalyticalField(b_x=b_x, b_y=b_y, constants=[-100])
+
+    # Create bunch.
+    emitt_nx = emitt_ny = 1e-6  # m
+    beta_x = beta_y = 1.  # m
+    s_t = 100.  # fs
+    gamma_avg = 1000
+    ene_spread = 0.1  # %
+    q_bunch = 30  # pC
+    xi_avg = 0.  # m
+    n_part = 1e4
+    bunch = get_gaussian_bunch_from_twiss(
+        en_x=emitt_nx, en_y=emitt_ny, a_x=0, a_y=0, b_x=beta_x, b_y=beta_y,
+        ene=gamma_avg, ene_sp=ene_spread, s_t=s_t, xi_c=xi_avg,
+        q_tot=q_bunch, n_part=n_part, name='elec_bunch')
+
+    # Create field element.
+    element = FieldElement(
+        length=1,
+        dt_bunch=1e-3/ct.c,
+        n_out=10,
+        fields=[b_theta]
+    )
+
+    # Do tracking.
+    element.track(bunch, opmd_diag=True)
+
+    # Check that results have not changed.
+    bunch_params = analyze_bunch(bunch)
+    beta_x = bunch_params['beta_x']
+    assert approx(beta_x, rel=1e-10) == 0.054508554263608434
+
+
+if __name__ == '__main__':
+    test_field_element_tracking()

--- a/wake_t/beamline_elements/__init__.py
+++ b/wake_t/beamline_elements/__init__.py
@@ -3,8 +3,9 @@ from .plasma_stage import PlasmaStage
 from .plasma_ramp import PlasmaRamp
 from .active_plasma_lens import ActivePlasmaLens
 from .beamline import Beamline
+from .field_element import FieldElement
 
 
 __all__ = [
     'Drift', 'Dipole', 'Quadrupole', 'Sextupole', 'PlasmaStage', 'PlasmaRamp',
-    'ActivePlasmaLens', 'Beamline']
+    'ActivePlasmaLens', 'Beamline', 'FieldElement']

--- a/wake_t/beamline_elements/beamline.py
+++ b/wake_t/beamline_elements/beamline.py
@@ -8,7 +8,7 @@ class Beamline():
     def __init__(self, elements):
         self.elements = elements
 
-    def track(self, bunch, out_initial=True, opmd_diag=False, diag_dir=None):
+    def track(self, bunch, opmd_diag=False, diag_dir=None):
         """
         Track bunch through beamline.
 
@@ -16,11 +16,6 @@ class Beamline():
         -----------
         bunch : ParticleBunch
             Particle bunch to be tracked.
-
-        out_initial : bool
-            Determines whether the initial bunch should be included in the
-            output bunch list. This applies only at the beginning and not for
-            every beamline element.
 
         opmd_diag : bool or OpenPMDDiagnostics
             Determines whether to write simulation diagnostics to disk (i.e.
@@ -43,12 +38,6 @@ class Beamline():
         bunch_list = []
         if type(opmd_diag) is not OpenPMDDiagnostics and opmd_diag:
             opmd_diag = OpenPMDDiagnostics(write_dir=diag_dir)
-        for i, element in enumerate(self.elements):
-            bunch_list.extend(
-                element.track(
-                    bunch,
-                    out_initial=out_initial and i == 0,
-                    opmd_diag=opmd_diag
-                    )
-                )
+        for element in self.elements:
+            bunch_list.extend(element.track(bunch, opmd_diag=opmd_diag))
         return bunch_list

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -1,0 +1,115 @@
+import scipy.constants as ct
+
+from wake_t.diagnostics import OpenPMDDiagnostics
+from wake_t.tracking.tracker import Tracker
+
+
+class FieldElement():
+    """ Generic class for any beamline element based on field tracking. """
+
+    def __init__(self, length, dt_bunch, bunch_pusher='rk4', n_out=1,
+                 name='field element', fields=[], auto_dt_bunch=None):
+        """
+        Initialize element.
+
+        Parameters
+        ----------
+        length : float
+            Length of the plasma stage in m.
+
+        dt_bunch : float
+            The time step for evolving the particle bunches. An adaptive time
+            step can be used if this parameter is set to `'auto'` and a
+            `auto_dt_bunch` function is provided.
+
+        bunch_pusher : str
+            The pusher used to evolve the particle bunches in time within
+            the specified fields. Possible values are 'rk4' (Runge-Kutta
+            method of 4th order) or 'boris' (Boris method).
+
+        n_out : int
+            Number of times along the stage in which the particle distribution
+            should be returned (A list with all output bunches is returned
+            after tracking).
+
+        name : str
+            Name of the plasma stage. This is only used for displaying the
+            progress bar during tracking. By default, `'Plasma stage'`.
+
+        fields : list
+            List of Fields that will be applied to the particle bunches.
+
+        auto_dt_bunch_f : callable, optional
+            Function used to determine the adaptive time step for bunches in
+            which the time step is set to `'auto'`. The function should take
+            solely a `ParticleBunch` as argument.
+
+        """
+        self.length = length
+        self.bunch_pusher = bunch_pusher
+        self.dt_bunch = dt_bunch
+        self.n_out = n_out
+        self.name = name
+        self.fields = fields
+        self.auto_dt_bunch = auto_dt_bunch
+
+    def track(self, bunches=[], opmd_diag=False, diag_dir=None):
+        """
+        Track bunch through plasma stage.
+
+        Parameters:
+        -----------
+        bunches : ParticleBunch or list of ParticleBunch
+            Particle bunches to be tracked.
+
+        opmd_diag : bool or OpenPMDDiagnostics
+            Determines whether to write simulation diagnostics to disk (i.e.
+            particle distributions and fields). The output is written to
+            HDF5 files following the openPMD standard. The number of outputs
+            the `n_out` value. It is also possible to provide an already
+            existing OpenPMDDiagnostics instance instead of a boolean value.
+
+        diag_dir : str
+            Directory into which the openPMD output will be written. By default
+            this is a 'diags' folder in the current directory. Only needed if
+            `opmd_diag=True`.
+
+        Returns:
+        --------
+        A list of size 'n_out' containing the bunch distribution at each step.
+
+        """
+        # Make sure `bunches` is a list.
+        if not isinstance(bunches, list):
+            bunches = [bunches]
+
+        if not isinstance(self.dt_bunch, list):
+            dt_bunch = [self.dt_bunch] * len(bunches)
+        else:
+            dt_bunch = self.dt_bunches
+
+        # Create diagnostics instance.
+        if type(opmd_diag) is not OpenPMDDiagnostics and opmd_diag:
+            opmd_diag = OpenPMDDiagnostics(write_dir=diag_dir)
+
+        # Create tracker.
+        tracker = Tracker(
+            t_final=self.length/ct.c,
+            bunches=bunches,
+            dt_bunches=dt_bunch,
+            fields=self.fields,
+            n_diags=self.n_out,
+            opmd_diags=opmd_diag,
+            bunch_pusher=self.bunch_pusher,
+            auto_dt_bunch_f=self.auto_dt_bunch,
+            section_name=self.name
+        )
+
+        # Do tracking.
+        bunch_list = tracker.do_tracking()
+
+        # If only tracking one bunch, do not return list of lists.
+        if len(bunch_list) == 1:
+            bunch_list = bunch_list[0]
+
+        return bunch_list


### PR DESCRIPTION
Implement new base `FieldElement` class for all beamline elements where the particle beams are tracked in external fields (as opposed to `TMElement`, where the tracking is performed with transfer matrices).

As a result, the `PlasmaStage` and all it's subclasses are now also `FieldElement`s.