### PR TITLE
Fix section title in the documentation

### DIFF
--- a/docs/source/api/particles/index.rst
+++ b/docs/source/api/particles/index.rst
@@ -1,8 +1,8 @@
 Particles
 =========
 
-Analytical fields
------------------
+Particle bunches
+----------------
 .. currentmodule:: wake_t.particles.particle_bunch
 .. autosummary::
    :toctree: _autosummary


### PR DESCRIPTION
Fixes a mistake in the title of a section in the documentation.