### PR TITLE
openPMD-api: No Upper Limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     numba
     scipy
     aptools~=0.2.0
-    openpmd-api~=0.14.0
+    openpmd-api
     tqdm
 python_requires = >=3.7
 


### PR DESCRIPTION
We use semver and use major versions for potentially breaking changes. Practically, we only break the Python API very slightly every 2-3 years.

Thus, removing upper version contrain for better maintainability and following best practice.