### PR TITLE
Change input parameters of ramp profiles

### DIFF
--- a/wake_t/beamline_elements/plasma_ramp.py
+++ b/wake_t/beamline_elements/plasma_ramp.py
@@ -133,7 +133,7 @@ class PlasmaRamp(PlasmaStage):
         # If a function profile is not provided, generate from presets.
         if not callable(profile):
             if profile in ramp_profiles:
-                profile = ramp_profiles[profile]                
+                profile = ramp_profiles[profile]
             else:
                 raise ValueError(
                     'Ramp profile "{}" not recognized'.format(profile))


### PR DESCRIPTION
Density profiles given to a plasma ramp now need to include the input parameters `decay_length`, `density_top`, `density_down` and `position_down`. This makes them consistent with the predefined profiles included by default.