### PR TITLE
Avoid using latest numba release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 install_requires =
     numpy
-    numba
+    numba<0.57
     scipy
     aptools~=0.2.0
     openpmd-api


### PR DESCRIPTION
There seems to be an issue with the latest numba release (0.57) where the output of `np.angle` seems to be `complex128`. This prevents the laser envelope solver from compiling.

This PR prevents Wake-T from installing numba 0.57 until we find a more appropriate solution.