### PR TITLE
Raise `RuntimeError` for numba 0.57.0

### DIFF
--- a/wake_t/__init__.py
+++ b/wake_t/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 from .beamline_elements import (PlasmaStage, PlasmaRamp, ActivePlasmaLens,

--- a/wake_t/utilities/numba.py
+++ b/wake_t/utilities/numba.py
@@ -1,7 +1,14 @@
 """This module contains custom definitions of the numba decorators."""
 
 import os
-from numba import njit
+from numba import njit, __version__ as numba_version
+
+
+if numba_version == '0.57.0':
+    raise RuntimeError(
+        'Wake-T is incompatible with numba 0.57.0.\n'
+        'Please install either a later or an earlier version.'
+    )
 
 
 # Check if the environment variable WAKET_DISABLE_CACHING is set to 1


### PR DESCRIPTION
Follow up to #121.