### PR TITLE
Avoid numba `0.57.0` only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 packages = find:
 install_requires =
     numpy
-    numba<0.57
+    numba!=0.57.0
     scipy
     aptools~=0.2.0
     openpmd-api


### PR DESCRIPTION
Only avoid `0.57.0` (which had issues with the envelope solver #121) instead of restricting to `<0.57`.