### PR TITLE
Update PyPI action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,28 +8,28 @@ jobs:
   build-n-publish:
     name: Build and publish package to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install pypa/build
       run: >-
-        python -m
+        python3 -m
         pip install
         build
         --user
     - name: Build a binary wheel and a source tarball
       run: >-
-        python -m
+        python3 -m
         build
         --sdist
         --wheel
         --outdir dist/
         .
-    - name: Publish distribution to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The action to publish to PyPI was outdated and no longer working. This PR updates it to use `actions/setup-python@v4` as well trusted publishing in PyPI.