### PR TITLE
Implement `lasy` reader

### DIFF
--- a/docs/source/api/laser/laser_pulses/index.rst
+++ b/docs/source/api/laser/laser_pulses/index.rst
@@ -10,3 +10,4 @@ Laser pulses
    LaguerreGaussPulse
    FlattenedGaussianPulse
    SummedPulse
+   OpenPMDPulse

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -184,12 +184,17 @@ class RZWakefield(NumericalField):
             [np.ascontiguousarray(self.rho.T[2:-2, 2:-2]) * self.n_p * (-ct.e)]
         ]
         if self.laser is not None:
-            fld_names += ['a_mod', 'a_phase']
-            fld_comps += [None, None]
-            fld_attrs += [{'polarization': self.laser.polarization}, {}]
+            fld_names += ['a_mod', 'a_phase', 'a']
+            fld_comps += [None, None, None]
+            fld_attrs += [
+                {'polarization': self.laser.polarization},
+                {},
+                {'angularFrequency': 2 * np.pi * ct.c / self.laser.l_0}
+            ]
             fld_arrays += [
                 [np.ascontiguousarray(np.abs(self.laser.get_envelope().T))],
-                [np.ascontiguousarray(np.angle(self.laser.get_envelope().T))]
+                [np.ascontiguousarray(np.angle(self.laser.get_envelope().T))],
+                [np.ascontiguousarray(self.laser.get_envelope().T)]
             ]
         fld_comp_pos = [fld_position] * len(fld_names)
 

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -16,11 +16,11 @@ from scipy.special import genlaguerre, binom
 try:
     from lasy.profiles.from_openpmd_profile import FromOpenPMDProfile
     from lasy.laser import Laser
-    from lasy.utils.laser_utils import field_to_a0
+    from lasy.utils.laser_utils import field_to_vector_potential
     lasy_installed = True
 except ImportError:
     lasy_installed = False
-    
+
 
 from .envelope_solver import evolve_envelope
 from .envelope_solver_non_centered import evolve_envelope_non_centered
@@ -596,7 +596,7 @@ class OpenPMDPulse(LaserPulse):
         field: str = 'E',
         coord: str = 'x',
         envelope: bool = False,
-        prefix: str = None, # only needed if `envelope=True`
+        prefix: str = None,  # only needed if `envelope=True`
         theta: float = 0.
     ) -> None:
         assert lasy_installed, (
@@ -632,5 +632,7 @@ class OpenPMDPulse(LaserPulse):
             profile=self.lasy_profile,
             n_azimuthal_modes=1
         )
-        a_env = field_to_a0(laser.grid, laser.profile.omega0)[0].T[::-1]
+        a_env = field_to_vector_potential(laser.grid, laser.profile.omega0)
+        # Get, transpose and invert 2D slice
+        a_env = a_env[0].T[::-1]
         return a_env

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -618,7 +618,7 @@ class OpenPMDPulse(LaserPulse):
         iteration: int,
         field: str = 'E',
         coord: str = 'x',
-        prefix: str = None,  # only needed if `envelope=True`
+        prefix: str = None,
         theta: float = 0.
     ) -> None:
         assert lasy_installed, (
@@ -628,7 +628,7 @@ class OpenPMDPulse(LaserPulse):
         self.lasy_profile = FromOpenPMDProfile(
             path=path,
             iteration=iteration,
-            pol=(1, 0),  # probably not needed
+            pol=(1, 0),  # dummy value, currently not needed
             field=field,
             coord=coord,
             prefix=prefix,

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -604,10 +604,6 @@ class OpenPMDPulse(LaserPulse):
         Name of the field containing the laser pulse.
     coord : string
         Coordinate of the field containing the laser pulse.
-    envelope : boolean
-        Whether the file represents a laser envelope.
-        If not, the envelope is obtained from the electric field
-        using a Hilbert transform.
     prefix : string
         Prefix of the openPMD file from which the envelope is read.
         Only used when envelope=True.
@@ -622,7 +618,6 @@ class OpenPMDPulse(LaserPulse):
         iteration: int,
         field: str = 'E',
         coord: str = 'x',
-        envelope: bool = False,
         prefix: str = None,  # only needed if `envelope=True`
         theta: float = 0.
     ) -> None:
@@ -636,7 +631,6 @@ class OpenPMDPulse(LaserPulse):
             pol=(1, 0),  # probably not needed
             field=field,
             coord=coord,
-            envelope=envelope,
             prefix=prefix,
             theta=theta
         )

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -606,7 +606,7 @@ class OpenPMDPulse(LaserPulse):
         self.lasy_profile = FromOpenPMDProfile(
             path=path,
             iteration=iteration,
-            pol=(0,0),  # probably not needed
+            pol=(1, 0),  # probably not needed
             field=field,
             coord=coord,
             envelope=envelope,

--- a/wake_t/physics_models/laser/laser_pulse.py
+++ b/wake_t/physics_models/laser/laser_pulse.py
@@ -589,6 +589,33 @@ class FlattenedGaussianPulse(LaserPulse):
 
 
 class OpenPMDPulse(LaserPulse):
+    """Read a laser pulse from an openPMD file.
+
+    This class requires `lasy <https://lasydoc.readthedocs.io>`_ to be
+    installed.
+
+    Parameters
+    ----------
+    path : str
+        Path to the openPMD file or folder containing the laser data.
+    iteration : int
+        Iteration at which to read the laser pulse.
+    field : str
+        Name of the field containing the laser pulse.
+    coord : string
+        Coordinate of the field containing the laser pulse.
+    envelope : boolean
+        Whether the file represents a laser envelope.
+        If not, the envelope is obtained from the electric field
+        using a Hilbert transform.
+    prefix : string
+        Prefix of the openPMD file from which the envelope is read.
+        Only used when envelope=True.
+        The provided iteration is read from <path>/<prefix>_%T.h5.
+    theta : float or None, optional
+        Only used if the openPMD input is in thetaMode geometry.
+        The angle of the plane of observation, with respect to the x axis.
+    """
     def __init__(
         self,
         path: str,


### PR DESCRIPTION
This PR implements the possibility of reading a laser pulse from an openPMD file using the `lasy` library. In addition, the laser diagnostics of a Wake-T simulation now include the full complex envelope `a`.