### PR TITLE
Fix bug when passing a list to `dt_bunch`

### DIFF
--- a/tests/test_field_element.py
+++ b/tests/test_field_element.py
@@ -1,4 +1,5 @@
 import os
+import copy
 
 import numpy as np
 import scipy.constants as ct
@@ -98,9 +99,11 @@ def test_field_element_error():
 
     # Check that an error is raised because the number of `dt_bunch` does
     # not agree with the number of bunches.
-    diag_dir = os.path.join(output_folder, 'diags')
     with raises(ValueError) as e_info:
-        element.track(bunch, opmd_diag=True, diag_dir=diag_dir)
+        element.track(bunch, opmd_diag=False)
+    # This one should instead work.
+    element.track([bunch, copy.deepcopy(bunch)], opmd_diag=False)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_field_element.py
+++ b/tests/test_field_element.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 import scipy.constants as ct
-from pytest import approx
+from pytest import approx, raises
 
 from wake_t.utilities.bunch_generation import get_gaussian_bunch_from_twiss
 from wake_t.fields.analytical_field import AnalyticalField
@@ -69,5 +69,40 @@ def test_field_element_tracking():
     assert approx(beta_x, rel=1e-10) == 0.054508554263608434
 
 
+def test_field_element_error():
+    """Test that the expected errors are raised"""
+    output_folder = os.path.join(
+        tests_output_folder, 'test_field_element_tracking')
+
+    # Create bunch.
+    emitt_nx = emitt_ny = 1e-6  # m
+    beta_x = beta_y = 1.  # m
+    s_t = 100.  # fs
+    gamma_avg = 1000
+    ene_spread = 0.1  # %
+    q_bunch = 30  # pC
+    xi_avg = 0.  # m
+    n_part = 1e4
+    bunch = get_gaussian_bunch_from_twiss(
+        en_x=emitt_nx, en_y=emitt_ny, a_x=0, a_y=0, b_x=beta_x, b_y=beta_y,
+        ene=gamma_avg, ene_sp=ene_spread, s_t=s_t, xi_c=xi_avg,
+        q_tot=q_bunch, n_part=n_part, name='elec_bunch')
+
+    # Create field element with too many dt_bunch.
+    element = FieldElement(
+        length=1,
+        dt_bunch=[1e-3/ct.c, 1e-3/ct.c],
+        n_out=10,
+        fields=[],
+    )
+
+    # Check that an error is raised because the number of `dt_bunch` does
+    # not agree with the number of bunches.
+    diag_dir = os.path.join(output_folder, 'diags')
+    with raises(ValueError) as e_info:
+        element.track(bunch, opmd_diag=True, diag_dir=diag_dir)
+
+
 if __name__ == '__main__':
     test_field_element_tracking()
+    test_field_element_error()

--- a/wake_t/beamline_elements/active_plasma_lens.py
+++ b/wake_t/beamline_elements/active_plasma_lens.py
@@ -5,7 +5,7 @@ from typing import Optional, Union, Callable
 import numpy as np
 import scipy.constants as ct
 
-from wake_t.beamline_elements import PlasmaStage
+from .plasma_stage import PlasmaStage, DtBunchType
 from wake_t.physics_models.em_fields.linear_b_theta import LinearBThetaField
 
 
@@ -42,6 +42,15 @@ class ActivePlasmaLens(PlasmaStage):
         The pusher used to evolve the particle bunches in time within
         the specified fields. Possible values are ``'rk4'`` (Runge-Kutta
         method of 4th order) or ``'boris'`` (Boris method).
+    dt_bunch : float
+        The time step for evolving the particle bunches. If ``None``, it will
+        be automatically set to :math:`dt = T/(10*2*pi)`, where T is the
+        smallest expected betatron period of the bunch along the plasma lens
+        (T is calculated from `foc_strength` if `wakefields=False`,
+        otherwise the focusing strength of a blowout is used).
+        A list of values can also be provided. In this case, the list
+        should have the same order as the list of bunches given to the
+        ``track`` method.
     n_out : int
         Number of times along the lens in which the particle distribution
         should be returned (A list with all output bunches is returned
@@ -68,7 +77,7 @@ class ActivePlasmaLens(PlasmaStage):
         density: Optional[Union[float, Callable[[float], float]]] = None,
         wakefield_model: Optional[str] = 'quasistatic_2d',
         bunch_pusher: Optional[str] = 'rk4',
-        dt_bunch: Optional[Union[float, int]] = 'auto',
+        dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Active plasma lens',
         **model_params

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -94,7 +94,7 @@ class FieldElement():
         if not isinstance(self.dt_bunch, list):
             dt_bunch = [self.dt_bunch] * len(bunches)
         else:
-            dt_bunch = self.dt_bunches
+            dt_bunch = self.dt_bunch
 
         # Create diagnostics instance.
         if type(opmd_diag) is not OpenPMDDiagnostics and opmd_diag:

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -16,10 +16,12 @@ class FieldElement():
     ----------
     length : float or str
         Length of the plasma stage in m.
-    dt_bunch : float
+    dt_bunch : float, str or list of float and str
         The time step for evolving the particle bunches. An adaptive time
         step can be used if this parameter is set to ``'auto'`` and a
-        ``auto_dt_bunch`` function is provided.
+        ``auto_dt_bunch`` function is provided. A list of values can
+        also be provided. In this case, the list should have the same order as
+        the list of bunches given to the ``track`` method.
     bunch_pusher : str
         The pusher used to evolve the particle bunches in time within
         the specified fields. Possible values are ``'rk4'`` (Runge-Kutta
@@ -43,7 +45,7 @@ class FieldElement():
     def __init__(
         self,
         length: float,
-        dt_bunch: Union[float, str],
+        dt_bunch: Union[float, str, List[Union[float, str]]],
         bunch_pusher: Optional[str] = 'rk4',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'field element',
@@ -94,6 +96,11 @@ class FieldElement():
         if not isinstance(self.dt_bunch, list):
             dt_bunch = [self.dt_bunch] * len(bunches)
         else:
+            if len(self.dt_bunch) != len(bunches):
+                raise ValueError(
+                    f'The number of time steps ({len(self.dt_bunch)}) '
+                    f'does not match the number of bunches ({len(bunches)}).'
+                )
             dt_bunch = self.dt_bunch
 
         # Create diagnostics instance.

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -89,17 +89,17 @@ class FieldElement():
         A list of size 'n_out' containing the bunch distribution at each step.
 
         """
-        # Make sure `bunches` is a list.
+        # Make sure `bunches` and `dt_bunch` are lists.
         if not isinstance(bunches, list):
             bunches = [bunches]
-
         if not isinstance(self.dt_bunch, list):
             dt_bunch = [self.dt_bunch] * len(bunches)
         else:
-            if len(self.dt_bunch) != len(bunches):
+            n_dt, n_bunches = len(self.dt_bunch), len(bunches)
+            if n_dt != n_bunches:
                 raise ValueError(
-                    f'The number of time steps ({len(self.dt_bunch)}) '
-                    f'does not match the number of bunches ({len(bunches)}).'
+                    f'The number of time steps in `dt_bunch` ({n_dt}) '
+                    f'does not match the number of bunches ({n_bunches}).'
                 )
             dt_bunch = self.dt_bunch
 

--- a/wake_t/beamline_elements/plasma_ramp.py
+++ b/wake_t/beamline_elements/plasma_ramp.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import numpy as np
 
-from wake_t.beamline_elements import PlasmaStage
+from .plasma_stage import PlasmaStage, DtBunchType
 
 
 # Define type alias for the ramp profiles.
@@ -93,6 +93,9 @@ class PlasmaRamp(PlasmaStage):
         The time step for evolving the particle bunches. If ``None``, it will
         be automatically set to :math:`dt = T/(10*2*pi)`, where T is the
         smallest expected betatron period of the bunch along the plasma stage.
+        A list of values can also be provided. In this case, the list
+        should have the same order as the list of bunches given to the
+        ``track`` method.
     n_out : int
         Number of times along the stage in which the particle distribution
         should be returned (A list with all output bunches is returned
@@ -122,7 +125,7 @@ class PlasmaRamp(PlasmaStage):
         plasma_dens_down: Optional[float] = None,
         position_down: Optional[float] = None,
         bunch_pusher: Optional[str] = 'rk4',
-        dt_bunch: Optional[Union[float, int]] = 'auto',
+        dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma ramp',
         **model_params

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -10,6 +10,9 @@ from wake_t.fields.base import Field
 from .field_element import FieldElement
 
 
+DtBunchType = Optional[Union[float, str, List[Union[float, str]]]]
+
+
 wakefield_models = {
     'simple_blowout': wf.SimpleBlowoutWakefield,
     'custom_blowout': wf.CustomBlowoutWakefield,
@@ -38,11 +41,13 @@ class PlasmaStage(FieldElement):
         The pusher used to evolve the particle bunches in time within
         the specified fields. Possible values are ``'rk4'`` (Runge-Kutta
         method of 4th order) or ``'boris'`` (Boris method).
-    dt_bunch : float, optional
-        The time step for evolving the particle bunches. If ``None``, it
+    dt_bunch : float, str or list of float or str, optional
+        The time step for evolving the particle bunches. If ``'auto'``, it
         will be automatically set to ``dt = T/(10*2*pi)``, where T is the
         smallest expected betatron period of the bunch along the plasma
-        stage.
+        stage. A list of values can also be provided. In this case, the list
+        should have the same order as the list of bunches given to the
+        ``track`` method.
     n_out : int, optional
         Number of times along the stage in which the particle distribution
         should be returned (A list with all output bunches is returned
@@ -71,7 +76,7 @@ class PlasmaStage(FieldElement):
         density: Union[float, Callable[[float], float]],
         wakefield_model: Optional[str] = 'simple_blowout',
         bunch_pusher: Optional[str] = 'rk4',
-        dt_bunch: Optional[Union[float, int]] = 'auto',
+        dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma stage',
         external_fields: Optional[List[Field]] = [],

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -10,7 +10,7 @@ from wake_t.fields.base import Field
 from .field_element import FieldElement
 
 
-DtBunchType = Optional[Union[float, str, List[Union[float, str]]]]
+DtBunchType = Union[float, str, List[Union[float, str]]]
 
 
 wakefield_models = {


### PR DESCRIPTION
Although in principle it is possible to pass a list of values to `dt_bunch`  (one value per bunch), this functionality was not documented nor functional. This PR fixes this issue.