### PR TITLE
Make `boris` the default bunch pusher and enable parallelism

### DIFF
--- a/tests/test_active_plasma_lens.py
+++ b/tests/test_active_plasma_lens.py
@@ -29,7 +29,7 @@ def test_active_plasma_lens():
     apl.track(bunch)
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 92.14017315271572
+    assert approx(gamma_x, rel=1e-10) == 92.38646379897074
 
 
 def test_active_plasma_lens_with_wakefields():
@@ -64,7 +64,7 @@ def test_active_plasma_lens_with_wakefields():
     # Analyze and check results.
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 77.32004939154773
+    assert approx(gamma_x, rel=1e-10) == 77.31995824746237
 
 
 if __name__ == '__main__':

--- a/tests/test_field_element.py
+++ b/tests/test_field_element.py
@@ -67,7 +67,7 @@ def test_field_element_tracking():
     # Check that results have not changed.
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert approx(beta_x, rel=1e-10) == 0.054508554263608434
+    assert approx(beta_x, rel=1e-10) == 0.05450127309723603
 
 
 def test_field_element_error():

--- a/tests/test_fluid_model.py
+++ b/tests/test_fluid_model.py
@@ -42,7 +42,7 @@ def test_fluid_model(plot=False):
 
     # Check final parameters.
     ene_sp = params_evolution['rel_ene_spread'][-1]
-    assert approx(ene_sp, rel=1e-10) == 0.024183646993930535
+    assert approx(ene_sp, rel=1e-10) == 0.024179998095119972
 
     # Quick plot of results.
     if plot:

--- a/tests/test_multibunch.py
+++ b/tests/test_multibunch.py
@@ -55,8 +55,8 @@ def test_multibunch_plasma_simulation(plot=False):
     # Assert final parameters are correct.
     final_energy_driver = driver_params['avg_ene'][-1]
     final_energy_witness = witness_params['avg_ene'][-1]
-    assert approx(final_energy_driver, rel=1e-10) == 1700.33213311266
-    assert approx(final_energy_witness, rel=1e-10) == 636.3355022503769
+    assert approx(final_energy_driver, rel=1e-10) == 1700.3927190416732
+    assert approx(final_energy_witness, rel=1e-10) == 636.330857261392
 
     if plot:
         z = driver_params['prop_dist'] * 1e2

--- a/tests/test_ramps.py
+++ b/tests/test_ramps.py
@@ -33,7 +33,7 @@ def test_downramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.009757682933057094
+    assert beta_x == 0.009750309290619276
 
 
 def test_upramp():
@@ -64,7 +64,7 @@ def test_upramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.0007641796148894145
+    assert beta_x == 0.0007631600676104024
 
 
 if __name__ == '__main__':

--- a/wake_t/beamline_elements/active_plasma_lens.py
+++ b/wake_t/beamline_elements/active_plasma_lens.py
@@ -67,7 +67,7 @@ class ActivePlasmaLens(PlasmaStage):
         wakefields: bool = False,
         density: Optional[Union[float, Callable[[float], float]]] = None,
         wakefield_model: Optional[str] = 'quasistatic_2d',
-        bunch_pusher: Optional[str] = 'rk4',
+        bunch_pusher: Optional[str] = 'boris',
         dt_bunch: Optional[Union[float, int]] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Active plasma lens',

--- a/wake_t/beamline_elements/active_plasma_lens.py
+++ b/wake_t/beamline_elements/active_plasma_lens.py
@@ -1,6 +1,6 @@
 """ This module contains the definition of the ActivePlasmaLens class """
 
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, Literal
 
 import numpy as np
 import scipy.constants as ct
@@ -76,7 +76,7 @@ class ActivePlasmaLens(PlasmaStage):
         wakefields: bool = False,
         density: Optional[Union[float, Callable[[float], float]]] = None,
         wakefield_model: Optional[str] = 'quasistatic_2d',
-        bunch_pusher: Optional[str] = 'boris',
+        bunch_pusher: Optional[Literal['boris', 'rk4']] = 'boris',
         dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Active plasma lens',

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -44,7 +44,7 @@ class FieldElement():
         self,
         length: float,
         dt_bunch: Union[float, str],
-        bunch_pusher: Optional[str] = 'rk4',
+        bunch_pusher: Optional[str] = 'boris',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'field element',
         fields: Optional[List[Field]] = [],

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Literal
 
 import scipy.constants as ct
 
@@ -46,7 +46,7 @@ class FieldElement():
         self,
         length: float,
         dt_bunch: Union[float, str, List[Union[float, str]]],
-        bunch_pusher: Optional[str] = 'boris',
+        bunch_pusher: Optional[Literal['boris', 'rk4']] = 'boris',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'field element',
         fields: Optional[List[Field]] = [],

--- a/wake_t/beamline_elements/plasma_ramp.py
+++ b/wake_t/beamline_elements/plasma_ramp.py
@@ -4,7 +4,7 @@ predefined ramp profiles.
 
 """
 
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, Literal
 from functools import partial
 
 import numpy as np
@@ -124,7 +124,7 @@ class PlasmaRamp(PlasmaStage):
         plasma_dens_top: Optional[float] = None,
         plasma_dens_down: Optional[float] = None,
         position_down: Optional[float] = None,
-        bunch_pusher: Optional[str] = 'boris',
+        bunch_pusher: Optional[Literal['boris', 'rk4']] = 'boris',
         dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma ramp',

--- a/wake_t/beamline_elements/plasma_ramp.py
+++ b/wake_t/beamline_elements/plasma_ramp.py
@@ -121,7 +121,7 @@ class PlasmaRamp(PlasmaStage):
         plasma_dens_top: Optional[float] = None,
         plasma_dens_down: Optional[float] = None,
         position_down: Optional[float] = None,
-        bunch_pusher: Optional[str] = 'rk4',
+        bunch_pusher: Optional[str] = 'boris',
         dt_bunch: Optional[Union[float, int]] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma ramp',

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -67,7 +67,7 @@ class PlasmaStage(FieldElement):
         length: float,
         density: Union[float, Callable[[float], float]],
         wakefield_model: Optional[str] = 'simple_blowout',
-        bunch_pusher: Optional[str] = 'rk4',
+        bunch_pusher: Optional[str] = 'boris',
         dt_bunch: Optional[Union[float, int]] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma stage',

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -1,6 +1,6 @@
 """ This module contains the definition of the PlasmaStage class """
 
-from typing import Optional, Union, Callable, List
+from typing import Optional, Union, Callable, List, Literal
 
 import numpy as np
 import scipy.constants as ct
@@ -75,7 +75,7 @@ class PlasmaStage(FieldElement):
         length: float,
         density: Union[float, Callable[[float], float]],
         wakefield_model: Optional[str] = 'simple_blowout',
-        bunch_pusher: Optional[str] = 'boris',
+        bunch_pusher: Optional[Literal['boris', 'rk4']] = 'boris',
         dt_bunch: Optional[DtBunchType] = 'auto',
         n_out: Optional[int] = 1,
         name: Optional[str] = 'Plasma stage',

--- a/wake_t/fields/analytical_field.py
+++ b/wake_t/fields/analytical_field.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, List
 import numpy as np
 
 from .base import Field
-from wake_t.utilities.numba import njit_serial
+from wake_t.utilities.numba import njit_parallel
 
 
 # Define type alias.
@@ -49,9 +49,10 @@ class AnalyticalField(Field):
 
     Examples
     --------
+    >>> from numba import prange
     >>> def linear_ex(x, y, z, t, ex, constants):
     ...     ex_slope = constants[0]
-    ...     for i in range(x.shape[0]):
+    ...     for i in prange(x.shape[0]):
     ...         ex[i] = ex_slope * x[i]
     ...
     >>> ex = AnalyticField(e_x=linear_ex, constants=[1e6])
@@ -76,12 +77,12 @@ class AnalyticalField(Field):
             """Default field component."""
             pass
 
-        self.__e_x = njit_serial(e_x) if e_x is not None else no_field
-        self.__e_y = njit_serial(e_y) if e_y is not None else no_field
-        self.__e_z = njit_serial(e_z) if e_z is not None else no_field
-        self.__b_x = njit_serial(b_x) if b_x is not None else no_field
-        self.__b_y = njit_serial(b_y) if b_y is not None else no_field
-        self.__b_z = njit_serial(b_z) if b_z is not None else no_field
+        self.__e_x = njit_parallel(e_x) if e_x is not None else no_field
+        self.__e_y = njit_parallel(e_y) if e_y is not None else no_field
+        self.__e_z = njit_parallel(e_z) if e_z is not None else no_field
+        self.__b_x = njit_parallel(b_x) if b_x is not None else no_field
+        self.__b_y = njit_parallel(b_y) if b_y is not None else no_field
+        self.__b_z = njit_parallel(b_z) if b_z is not None else no_field
         self.constants = np.array(constants)
 
     def _pre_gather(self, x, y, z, t):

--- a/wake_t/fields/gather.py
+++ b/wake_t/fields/gather.py
@@ -4,6 +4,7 @@ from typing import List
 
 import numpy as np
 
+from wake_t.utilities.numba import njit_parallel, prange
 from .base import Field
 
 
@@ -48,13 +49,20 @@ def gather_fields(
         1D array where the gathered Bz values will be stored
     """
     # Initially, set all field values to zero.
-    ex[:] = 0.
-    ey[:] = 0.
-    ez[:] = 0.
-    bx[:] = 0.
-    by[:] = 0.
-    bz[:] = 0.
+    reset_particle_fields(ex, ey, ez, bx, by, bz)
 
     # Gather contributions from all fields.
     for field in fields:
         field.gather(x, y, z, t, ex, ey, ez, bx, by, bz)
+
+
+@njit_parallel
+def reset_particle_fields(ex, ey, ez, bx, by, bz):
+    """Set bunch field arrays to zero."""
+    for i in prange(ex.size):
+        ex[i] = 0.
+        ey[i] = 0.
+        ez[i] = 0.
+        bx[i] = 0.
+        by[i] = 0.
+        bz[i] = 0.

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -10,7 +10,7 @@ implemented in FBPIC (https://github.com/fbpic/fbpic).
 import math
 import numpy as np
 
-from wake_t.utilities.numba import njit_parallel, prange
+from wake_t.utilities.numba import njit_serial, prange
 
 
 def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
@@ -59,7 +59,7 @@ def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
         raise ValueError(err_string)
 
 
-@njit_parallel
+@njit_serial
 def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                    deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming linear particle shape. """
@@ -146,7 +146,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     return
 
 
-@njit_parallel
+@njit_serial
 def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                   deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming cubic particle shape. """

--- a/wake_t/particles/deposition.py
+++ b/wake_t/particles/deposition.py
@@ -10,7 +10,7 @@ implemented in FBPIC (https://github.com/fbpic/fbpic).
 import math
 import numpy as np
 
-from wake_t.utilities.numba import njit_serial
+from wake_t.utilities.numba import njit_parallel, prange
 
 
 def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
@@ -59,7 +59,7 @@ def deposit_3d_distribution(z, x, y, w, z_min, r_min, nz, nr, dz, dr,
         raise ValueError(err_string)
 
 
-@njit_serial
+@njit_parallel
 def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                    deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming linear particle shape. """
@@ -83,7 +83,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     r_max = nr * dr
 
     # Loop over particles.
-    for i in range(z.shape[0]):
+    for i in prange(z.shape[0]):
         # Get particle components.
         x_i = x[i]
         y_i = y[i]
@@ -146,7 +146,7 @@ def deposit_3d_distribution_linear(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     return
 
 
-@njit_serial
+@njit_parallel
 def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
                                   deposition_array, use_ruyten=False):
     """ Calculate charge distribution assuming cubic particle shape. """
@@ -171,7 +171,7 @@ def deposit_3d_distribution_cubic(z, x, y, q, z_min, r_min, nz, nr, dz, dr,
     r_max = nr * dr
 
     # Loop over particles.
-    for i in range(z.shape[0]):
+    for i in prange(z.shape[0]):
         # Get particle components.
         x_i = x[i]
         y_i = y[i]

--- a/wake_t/particles/interpolation.py
+++ b/wake_t/particles/interpolation.py
@@ -12,10 +12,10 @@ shapes.
 import math
 import numpy as np
 
-from wake_t.utilities.numba import njit_serial
+from wake_t.utilities.numba import njit_serial, njit_parallel, prange
 
 
-@njit_serial()
+@njit_parallel()
 def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     """
     Interpolate a 2D field defined on an r-z grid to the particle positions
@@ -45,7 +45,7 @@ def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     fld_part = np.zeros(n_part)
 
     # Iterate over all particles.
-    for i in range(n_part):
+    for i in prange(n_part):
         # Get particle position.
         x_i = x[i]
         y_i = y[i]
@@ -87,7 +87,7 @@ def gather_field_cyl_linear(fld, z_min, z_max, r_min, r_max, dz, dr, x, y, z):
     return fld_part
 
 
-@njit_serial()
+@njit_parallel()
 def gather_main_fields_cyl_linear(
         er, ez, bt, z_min, z_max, r_min, r_max, dz, dr, x, y, z,
         ex_part, ey_part, ez_part, bx_part, by_part, bz_part):
@@ -117,7 +117,7 @@ def gather_main_fields_cyl_linear(
     n_part = x.shape[0]
 
     # Iterate over all particles.
-    for i in range(n_part):
+    for i in prange(n_part):
 
         # Get particle position.
         x_i = x[i]

--- a/wake_t/particles/particle_bunch.py
+++ b/wake_t/particles/particle_bunch.py
@@ -288,6 +288,11 @@ class ParticleBunch():
             apply_rk4_pusher(self, fields, t, dt)
         elif pusher == 'boris':
             apply_boris_pusher(self, fields, t, dt)
+        else:
+            raise ValueError(
+                f"Bunch pusher '{pusher}' not recognized. "
+                "Possible values are 'boris' and 'rk4'"
+            )
         self.prop_distance += dt * ct.c
 
     def get_field_arrays(self):

--- a/wake_t/particles/push/boris_pusher.py
+++ b/wake_t/particles/push/boris_pusher.py
@@ -5,8 +5,9 @@ Authors: Jorge Ordóñez Carrasco, Ángel Ferran Pousa.
 """
 import numpy as np
 import scipy.constants as ct
+from numba import prange
 
-from wake_t.utilities.numba import njit_serial
+from wake_t.utilities.numba import njit_parallel
 from wake_t.fields.gather import gather_fields
 
 
@@ -42,9 +43,9 @@ def apply_boris_pusher(bunch, fields, t, dt):
         bunch.x, bunch.y, bunch.xi, bunch.px, bunch.py, bunch.pz, dt)
 
 
-@njit_serial()
+@njit_parallel()
 def apply_half_position_push(x, y, xi, px, py, pz, dt):
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         # Get particle momentum
         px_i = px[i]
         py_i = py[i]
@@ -58,11 +59,11 @@ def apply_half_position_push(x, y, xi, px, py, pz, dt):
         xi[i] += 0.5 * (pz_i * c_over_gamma_i - ct.c) * dt
 
 
-@njit_serial()
+@njit_parallel()
 def push_momentum(px, py, pz, ex, ey, ez, bx, by, bz, dt, q_over_mc):
     k = q_over_mc * dt / 2
 
-    for i in range(px.shape[0]):
+    for i in prange(px.shape[0]):
         # Get particle momentum and fields.
         px_i = px[i]
         py_i = py[i]

--- a/wake_t/particles/push/runge_kutta_4.py
+++ b/wake_t/particles/push/runge_kutta_4.py
@@ -2,8 +2,9 @@
 
 import math
 import scipy.constants as ct
+from numba import prange
 
-from wake_t.utilities.numba import njit_serial
+from wake_t.utilities.numba import njit_parallel
 from wake_t.fields.gather import gather_fields
 
 
@@ -117,40 +118,40 @@ def apply_rk4_pusher(bunch, fields, t, dt):
     apply_push(bunch.pz, dt, dpz)
 
 
-@njit_serial()
+@njit_parallel()
 def initialize_coord(x, x_0):
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         x[i] = x_0[i]
 
 
-@njit_serial()
+@njit_parallel()
 def update_coord(x, x_0, dt, k_x, fac):
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         x[i] = x_0[i] + dt * k_x[i] * fac
 
 
-@njit_serial()
+@njit_parallel()
 def initialize_push(dx, k_x, fac):
-    for i in range(dx.shape[0]):
+    for i in prange(dx.shape[0]):
         dx[i] = k_x[i] * fac
 
 
-@njit_serial()
+@njit_parallel()
 def update_push(dx, k_x, fac):
-    for i in range(dx.shape[0]):
+    for i in prange(dx.shape[0]):
         dx[i] += k_x[i] * fac
 
 
-@njit_serial()
+@njit_parallel()
 def apply_push(x, dt, dx):
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         x[i] += dt * dx[i]
 
 
-@njit_serial(fastmath=True, error_model='numpy')
+@njit_parallel(fastmath=True, error_model='numpy')
 def calculate_k(k_x, k_y, k_xi, k_px, k_py, k_pz,
                 q_over_mc, px, py, pz, ex, ey, ez, bx, by, bz):
-    for i in range(k_x.shape[0]):
+    for i in prange(k_x.shape[0]):
         px_i = px[i]
         py_i = py[i]
         pz_i = pz[i]

--- a/wake_t/physics_models/em_fields/linear_b_theta.py
+++ b/wake_t/physics_models/em_fields/linear_b_theta.py
@@ -1,19 +1,20 @@
 """ Defines a linearly-varying (in radius) azimuthal magnetic field """
 
 from wake_t.fields.analytical_field import AnalyticalField
+from wake_t.utilities.numba import prange
 
 
 def b_x(x, y, z, t, bx, constants):
     """B_x component."""
     k = constants[0]
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         bx[i] -= k * y[i]
 
 
 def b_y(x, y, z, t, by, constants):
     """B_y component."""
     k = constants[0]
-    for i in range(x.shape[0]):
+    for i in prange(x.shape[0]):
         by[i] += k * x[i]
 
 

--- a/wake_t/physics_models/plasma_wakefields/custom_blowout.py
+++ b/wake_t/physics_models/plasma_wakefields/custom_blowout.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.constants as ct
 
 from wake_t.fields.analytical_field import AnalyticalField
+from wake_t.utilities.numba import prange
 
 
 class CustomBlowoutWakefield(AnalyticalField):
@@ -36,12 +37,12 @@ class CustomBlowoutWakefield(AnalyticalField):
 
         def e_x(x, y, xi, t, ex, constants):
             k = constants[0]
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ex[i] = ct.c * k * x[i]
 
         def e_y(x, y, xi, t, ey, constants):
             k = constants[0]
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ey[i] = ct.c * k * y[i]
 
         def e_z(x, y, xi, t, ez, constants):
@@ -51,7 +52,7 @@ class CustomBlowoutWakefield(AnalyticalField):
             b_w = constants[4]
 
             xi_off = - xi_fields + (1 - b_w) * ct.c * t
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ez[i] = e_z_0 + e_z_p * (xi[i] + xi_off)
 
         super().__init__(e_x=e_x, e_y=e_y, e_z=e_z)

--- a/wake_t/physics_models/plasma_wakefields/focusing_blowout.py
+++ b/wake_t/physics_models/plasma_wakefields/focusing_blowout.py
@@ -2,6 +2,7 @@ import numpy as np
 import scipy.constants as ct
 
 from wake_t.fields.analytical_field import AnalyticalField
+from wake_t.utilities.numba import prange
 
 
 class FocusingBlowoutField(AnalyticalField):
@@ -9,11 +10,11 @@ class FocusingBlowoutField(AnalyticalField):
         self.density = density_function
 
         def e_x(x, y, xi, t, ex, k):
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ex[i] = ct.c * k[i] * x[i]
 
         def e_y(x, y, xi, t, ey, k):
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ey[i] = ct.c * k[i] * y[i]
 
         super().__init__(e_x=e_x, e_y=e_y)

--- a/wake_t/physics_models/plasma_wakefields/simple_blowout.py
+++ b/wake_t/physics_models/plasma_wakefields/simple_blowout.py
@@ -3,6 +3,7 @@ import scipy.constants as ct
 import aptools.plasma_accel.general_equations as ge
 
 from wake_t.fields.analytical_field import AnalyticalField
+from wake_t.utilities.numba import prange
 
 
 class SimpleBlowoutWakefield(AnalyticalField):
@@ -16,12 +17,12 @@ class SimpleBlowoutWakefield(AnalyticalField):
 
         def e_x(x, y, xi, t, ex, constants):
             k = constants[0]
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ex[i] = ct.c * k * x[i]
 
         def e_y(x, y, xi, t, ey, constants):
             k = constants[0]
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ey[i] = ct.c * k * y[i]
 
         def e_z(x, y, xi, t, ez, constants):
@@ -33,7 +34,7 @@ class SimpleBlowoutWakefield(AnalyticalField):
 
             # Precalculate offset.
             xi_off = l_p/2 - l_c - field_off + (1-b_w)*ct.c*t
-            for i in range(x.shape[0]):
+            for i in prange(x.shape[0]):
                 ez[i] = e_z_p * (xi[i] + xi_off)
 
         super().__init__(e_x=e_x, e_y=e_y, e_z=e_z)

--- a/wake_t/tracking/tracker.py
+++ b/wake_t/tracking/tracker.py
@@ -1,5 +1,5 @@
 """ This module contains the Tracker class. """
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, Literal
 from copy import deepcopy
 
 import numpy as np
@@ -77,7 +77,7 @@ class Tracker():
         n_diags: Optional[int] = 0,
         opmd_diags: Optional[OpenPMDDiagnostics] = None,
         auto_dt_bunch_f: Optional[Callable[[ParticleBunch], float]] = None,
-        bunch_pusher: Optional[str] = 'rk4',
+        bunch_pusher: Optional[Literal['boris', 'rk4']] = 'boris',
         section_name: Optional[str] = 'Simulation'
     ) -> None:
         self.t_final = t_final

--- a/wake_t/tracking/tracker.py
+++ b/wake_t/tracking/tracker.py
@@ -10,6 +10,9 @@ from wake_t.fields.base import Field
 from wake_t.fields.analytical_field import AnalyticalField
 from wake_t.fields.numerical_field import NumericalField
 from wake_t.diagnostics.openpmd_diag import OpenPMDDiagnostics
+from wake_t.utilities.numba import (
+    num_threads, set_num_threads, get_num_threads
+)
 from .progress_bar import get_progress_bar
 
 
@@ -125,6 +128,11 @@ class Tracker():
             Each item is another list with `n_diag` copies of the particle
             bunch along the tracking.
         """
+        # Get current number of threads before setting it to the number
+        # requested by Wake-T.
+        num_threads_outside_waket = get_num_threads()
+        set_num_threads(num_threads)
+
         # Initialize progress bar.
         progress_bar = get_progress_bar(self.section_name, self.t_final*ct.c)
 
@@ -214,6 +222,11 @@ class Tracker():
 
         # Close progress bar.
         progress_bar.close()
+
+        # Reset the number of threads to the value outside of Wake-T.
+        # This should help avoiding Wake-T to affect the behavior of other
+        # applications that require a different number of threads.
+        set_num_threads(num_threads_outside_waket)
 
         return self.bunch_list
 

--- a/wake_t/utilities/numba.py
+++ b/wake_t/utilities/numba.py
@@ -1,8 +1,11 @@
 """This module contains custom definitions of the numba decorators."""
 
 import os
-from numba import njit, __version__ as numba_version
 
+from numba import (
+    njit, __version__ as numba_version, set_num_threads, get_num_threads,
+    prange
+)
 
 if numba_version == '0.57.0':
     raise RuntimeError(
@@ -21,10 +24,9 @@ if 'WAKET_DISABLE_CACHING' in os.environ:
 
 # Check if the environment variable WAKET_DISABLE_CACHING is set to 1
 # and in that case, disable caching
-parallel = False
-if 'WAKET_PARALLEL' in os.environ:
-    if int(os.environ['WAKET_PARALLEL']) == 1:
-        parallel = True
+num_threads = 1
+if 'WAKET_NUM_THREADS' in os.environ:
+    num_threads = int(os.environ['WAKET_NUM_THREADS'])
 
 
 # Define custom njit decorator for serial methods.
@@ -34,4 +36,10 @@ def njit_serial(*args, **kwargs):
 
 # Define custom njit decorator for parallel methods.
 def njit_parallel(*args, **kwargs):
-    return njit(*args, cache=caching, parallel=parallel, **kwargs)
+    return njit(*args, cache=caching, parallel=True, **kwargs)
+
+
+__all__ = [
+    'njit_serial', 'njit_parallel', 'num_threads', 'set_num_threads',
+    'get_num_threads', 'prange'
+]

--- a/wake_t/utilities/numba.py
+++ b/wake_t/utilities/numba.py
@@ -19,6 +19,14 @@ if 'WAKET_DISABLE_CACHING' in os.environ:
         caching = False
 
 
+# Check if the environment variable WAKET_DISABLE_CACHING is set to 1
+# and in that case, disable caching
+parallel = False
+if 'WAKET_PARALLEL' in os.environ:
+    if int(os.environ['WAKET_PARALLEL']) == 1:
+        parallel = True
+
+
 # Define custom njit decorator for serial methods.
 def njit_serial(*args, **kwargs):
     return njit(*args, cache=caching, **kwargs)
@@ -26,4 +34,4 @@ def njit_serial(*args, **kwargs):
 
 # Define custom njit decorator for parallel methods.
 def njit_parallel(*args, **kwargs):
-    return njit(*args, cache=caching, parallel=True, **kwargs)
+    return njit(*args, cache=caching, parallel=parallel, **kwargs)


### PR DESCRIPTION
- Make `'boris'` the default pusher for the particle bunches.
- Raise a `ValueError` if the given `bunch_pusher` is not recognized.
- Faster particle gathering thanks to a more efficient method for resetting field arrays.
- Enable bunch pusher, bunch field gathering and analytical fields to run in parallel (other functions like those for bunch deposition are still serial. This will be gradually implemented).
- Define a new environment variable `'WAKET_NUM_THREADS'` that controls the number of parallel threads (by default, 1).