### PR TITLE
Require Python `>=3.8` and update tests

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
+        python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.8"
     nodejs: "16"
 
 # Build documentation in the docs/ directory with Sphinx

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -2,7 +2,7 @@
 
 Installation
 ============
-Wake-T is tested on Python 3.7 and above, so make sure to have an up-to-date version
+Wake-T is tested on Python 3.8 and above, so make sure to have an up-to-date version
 in order to avoid potential issues. It is recommended to install Wake-T in its
 own virtual environment, either using ``venv`` or ``conda``. The installation should be
 carried out with ``pip``, since Wake-T is available on `PyPI <https://pypi.org/project/Wake-T/>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     aptools~=0.2.0
     openpmd-api
     tqdm
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 test =

--- a/wake_t/__init__.py
+++ b/wake_t/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.4'
+__version__ = '0.7.0'
 
 
 from .beamline_elements import (PlasmaStage, PlasmaRamp, ActivePlasmaLens,


### PR DESCRIPTION
This PR removes support for Python 3.7. The supported (and tested) versions are now from 3.8 to ~3.12~ 3.11 (3.12 not yet supported by Numba https://github.com/numba/numba/issues/9197).