### PR TITLE
Push bunches before saving to diagnostics

### DIFF
--- a/tests/test_active_plasma_lens.py
+++ b/tests/test_active_plasma_lens.py
@@ -29,7 +29,7 @@ def test_active_plasma_lens():
     apl.track(bunch)
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 92.38646379897074
+    assert approx(gamma_x, rel=1e-10) == 92.38407675999406
 
 
 def test_active_plasma_lens_with_wakefields():
@@ -64,7 +64,7 @@ def test_active_plasma_lens_with_wakefields():
     # Analyze and check results.
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params['gamma_x']
-    assert approx(gamma_x, rel=1e-10) == 77.31995824746237
+    assert approx(gamma_x, rel=1e-10) == 77.32021188373825
 
 
 if __name__ == '__main__':

--- a/tests/test_custom_blowout.py
+++ b/tests/test_custom_blowout.py
@@ -46,7 +46,7 @@ def test_custom_blowout_wakefield(make_plots=False):
 
     bunch_params = analyze_bunch(bunch)
     rel_ene_sp = bunch_params['rel_ene_spread']
-    assert approx(rel_ene_sp, rel=1e-10) == 0.21192488237458038
+    assert approx(rel_ene_sp, rel=1e-10) == 0.21192494153185745
 
     if make_plots:
         # Analyze bunch evolution.

--- a/tests/test_fluid_model.py
+++ b/tests/test_fluid_model.py
@@ -42,7 +42,7 @@ def test_fluid_model(plot=False):
 
     # Check final parameters.
     ene_sp = params_evolution['rel_ene_spread'][-1]
-    assert approx(ene_sp, rel=1e-10) == 0.024179998095119972
+    assert approx(ene_sp, rel=1e-10) == 0.024157374564016194
 
     # Quick plot of results.
     if plot:

--- a/tests/test_multibunch.py
+++ b/tests/test_multibunch.py
@@ -55,8 +55,8 @@ def test_multibunch_plasma_simulation(plot=False):
     # Assert final parameters are correct.
     final_energy_driver = driver_params['avg_ene'][-1]
     final_energy_witness = witness_params['avg_ene'][-1]
-    assert approx(final_energy_driver, rel=1e-10) == 1700.3927190416732
-    assert approx(final_energy_witness, rel=1e-10) == 636.330857261392
+    assert approx(final_energy_driver, rel=1e-10) == 1700.3843657635728
+    assert approx(final_energy_witness, rel=1e-10) == 636.3260426124102
 
     if plot:
         z = driver_params['prop_dist'] * 1e2

--- a/tests/test_ramps.py
+++ b/tests/test_ramps.py
@@ -33,7 +33,7 @@ def test_downramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.009750309290619276
+    assert beta_x == 0.009750308724018872
 
 
 def test_upramp():
@@ -64,7 +64,7 @@ def test_upramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params['beta_x']
-    assert beta_x == 0.0007631600676104024
+    assert beta_x == 0.000763155045965493
 
 
 if __name__ == '__main__':

--- a/tests/test_simple_blowout.py
+++ b/tests/test_simple_blowout.py
@@ -45,7 +45,7 @@ def test_simple_blowout_wakefield(make_plots=False):
 
     bunch_params = analyze_bunch(bunch)
     rel_ene_sp = bunch_params['rel_ene_spread']
-    assert approx(rel_ene_sp, rel=1e-10) == 0.3637648484576557
+    assert approx(rel_ene_sp, rel=1e-10) == 0.3637651769109033
 
     if make_plots:
         # Analyze bunch evolution.

--- a/wake_t/beamline_elements/field_element.py
+++ b/wake_t/beamline_elements/field_element.py
@@ -64,7 +64,8 @@ class FieldElement():
         self,
         bunches: Optional[Union[ParticleBunch, List[ParticleBunch]]] = [],
         opmd_diag: Optional[Union[bool, OpenPMDDiagnostics]] = False,
-        diag_dir: Optional[str] = None
+        diag_dir: Optional[str] = None,
+        push_bunches_before_diags: Optional[bool] = True,
     ) -> Union[List[ParticleBunch], List[List[ParticleBunch]]]:
         """
         Track bunch through element.
@@ -83,6 +84,20 @@ class FieldElement():
             Directory into which the openPMD output will be written. By default
             this is a 'diags' folder in the current directory. Only needed if
             `opmd_diag=True`.
+        push_bunches_before_diags : bool, optional
+            Whether to push the bunches before saving them to the diagnostics.
+            Since the time step of the diagnostics can be different from that
+            of the bunches, it could happen that the bunches appear in the
+            diagnostics as they were at the last push, but not at the actual
+            time of the diagnostics. Setting this parameter to ``True``
+            (default) ensures that an additional push is given to all bunches
+            to evolve them to the diagnostics time before saving.
+            This additional push will always have a time step smaller than
+            the the time step of the bunch, so it has no detrimental impact
+            on the accuracy of the simulation. However, it could make
+            convergence studies more difficult to interpret,
+            since the number of pushes will depend on `n_diags`. Therefore,
+            it is exposed as an option so that it can be disabled if needed.
 
         Returns
         -------
@@ -119,6 +134,7 @@ class FieldElement():
             opmd_diags=opmd_diag,
             bunch_pusher=self.bunch_pusher,
             auto_dt_bunch_f=self.auto_dt_bunch,
+            push_bunches_before_diags=push_bunches_before_diags,
             section_name=self.name
         )
 

--- a/wake_t/tracking/tracker.py
+++ b/wake_t/tracking/tracker.py
@@ -253,7 +253,7 @@ class Tracker():
         set_num_threads(num_threads_outside_waket)
 
         return self.bunch_list
-    
+
     def evolve_bunch(
         self,
         bunch: ParticleBunch,


### PR DESCRIPTION
This PR adds a new option (set to `True` by default) to push the bunches before saving them to the diagnostics.

Since the time step of the diagnostics can be different from that of the bunches, it could happen that the bunches appear in the diagnostics as they were at the last push, but not at the actual time of the diagnostics. Setting this parameter to ``True`` (default) ensures that an additional push is given to all bunches to evolve them to the diagnostics time before saving. This additional push will always have a time step smaller than the the time step of the bunch, so it has no detrimental impact on the accuracy of the simulation. However, it could make convergence studies more difficult to interpret, since the number of pushes will depend on `n_diags`. Therefore, it is exposed as an option so that it can be disabled if needed.