### PR TITLE
Enable particle tracking of species added to wake-T

### DIFF
--- a/wake_t/diagnostics/openpmd_diag.py
+++ b/wake_t/diagnostics/openpmd_diag.py
@@ -205,14 +205,14 @@ class OpenPMDDiagnostics():
             particles['r_to_x'][SCALAR].set_attribute(
                 'macroWeighted', np.uint32(0))
             particles['r_to_x'][SCALAR].set_attribute('weightingPower', 1.)
-        if 'tag' in species_data:
-            tag = np.ascontiguousarray(species_data['tag'])
-            d_tag = Dataset(tag.dtype, extent=tag.shape)
-            particles['tag'][SCALAR].reset_dataset(d_tag)
-            particles['tag'][SCALAR].store_chunk(tag)
-            particles['tag'][SCALAR].set_attribute(
+        if 'id' in species_data:
+            ids = np.ascontiguousarray(species_data['id'])
+            d_id = Dataset(ids.dtype, extent=ids.shape)
+            particles['id'][SCALAR].reset_dataset(d_id)
+            particles['id'][SCALAR].store_chunk(ids)
+            particles['id'][SCALAR].set_attribute(
                 'macroWeighted', np.uint32(0))
-            particles['tag'][SCALAR].set_attribute('weightingPower', 1.)
+            particles['id'][SCALAR].set_attribute('weightingPower', 1.)
         q = species_data['q']
         m = species_data['m']
         d_q = Dataset(np.dtype('float64'), extent=[1])

--- a/wake_t/particles/particle_bunch.py
+++ b/wake_t/particles/particle_bunch.py
@@ -316,7 +316,8 @@ class ParticleBunch():
             prop_distance=deepcopy(self.prop_distance),
             name=deepcopy(self.name),
             q_species=deepcopy(self.q_species),
-            m_species=deepcopy(self.m_species)
+            m_species=deepcopy(self.m_species),
+            tags=deepcopy(self.tags)
         )
         bunch_copy.x_ref = self.x_ref
         bunch_copy.theta_ref = self.theta_ref

--- a/wake_t/particles/particle_bunch.py
+++ b/wake_t/particles/particle_bunch.py
@@ -257,9 +257,10 @@ class ParticleBunch():
             'm': self.m_species,
             'name': self.name,
             'z_off': global_time * ct.c,
-            'geometry': '3d_cartesian',
-            'id': self.tags
+            'geometry': '3d_cartesian'
         }
+        if self.tags is not None:
+            diag_dict['id'] = self.tags
         return diag_dict
 
     def show(self, **kwargs):

--- a/wake_t/particles/particle_bunch.py
+++ b/wake_t/particles/particle_bunch.py
@@ -257,7 +257,8 @@ class ParticleBunch():
             'm': self.m_species,
             'name': self.name,
             'z_off': global_time * ct.c,
-            'geometry': '3d_cartesian'
+            'geometry': '3d_cartesian',
+            'id': self.tags
         }
         return diag_dict
 


### PR DESCRIPTION
Here we add functionality to ensure that tracked particles that are added to wake-T from an external source (for example from a FBPIC simulation) can continue to be tracked throughout the Wake-T simulation.  

In practice this amounted to a realitvely small change, just passing the `tag`s in Wake-T through to the openpmd diagnostic and relabelling them as `id`.