### PR TITLE
Switch to new gridless solver by default

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -25,7 +25,7 @@ jobs:
         pip install -e ".[test]"
     - name: Run unit tests
       run: |
-        python -m pytest
+        python -m pytest --cov=wake_t --cov-report xml
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ test = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=wake_t --cov-report xml"
 testpaths = [
     "tests",
 ]

--- a/tests/test_active_plasma_lens.py
+++ b/tests/test_active_plasma_lens.py
@@ -96,7 +96,7 @@ def test_active_plasma_lens_with_wakefields():
     # Analyze and check results.
     bunch_params = analyze_bunch(bunch)
     gamma_x = bunch_params["gamma_x"]
-    assert approx(gamma_x, rel=1e-10) == 77.32021166792376
+    assert approx(gamma_x, rel=1e-10) == 77.43788529521473
 
 
 if __name__ == "__main__":

--- a/tests/test_multibunch.py
+++ b/tests/test_multibunch.py
@@ -79,8 +79,8 @@ def test_multibunch_plasma_simulation(plot=False):
     # Assert final parameters are correct.
     final_energy_driver = driver_params["avg_ene"][-1]
     final_energy_witness = witness_params["avg_ene"][-1]
-    assert approx(final_energy_driver, rel=1e-10) == 1700.38436683473
-    assert approx(final_energy_witness, rel=1e-9) == 636.3260401940877
+    assert approx(final_energy_driver, rel=1e-10) == 1702.126922131719
+    assert approx(final_energy_witness, rel=1e-9) == 636.7941326616957
 
     if plot:
         z = driver_params["prop_dist"] * 1e2

--- a/tests/test_parabolic_profile.py
+++ b/tests/test_parabolic_profile.py
@@ -117,7 +117,7 @@ def test_variable_parabolic_coefficient():
 
     # Check that both envelopes are equal.
     np.testing.assert_almost_equal(a_mod_2, a_mod_1)
-    np.testing.assert_almost_equal(a_phase_2, a_phase_1)
+    np.testing.assert_almost_equal(a_phase_2, a_phase_1, decimal=6)
 
     # Check final spot size value
     dr = r_max / Nr

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -20,7 +20,8 @@ wakefield_models = {
     "custom_blowout": wf.CustomBlowoutWakefield,
     "focusing_blowout": wf.FocusingBlowoutField,
     "cold_fluid_1d": wf.NonLinearColdFluidWakefield,
-    "quasistatic_2d": wf.Quasistatic2DWakefield,
+    "quasistatic_2d_legacy": wf.Quasistatic2DWakefield,
+    "quasistatic_2d": wf.Quasistatic2DWakefieldIon,  # For backward compatibility
     "quasistatic_2d_ion": wf.Quasistatic2DWakefieldIon,
 }
 


### PR DESCRIPTION
Whenever using `quasistatic_2d` as the wakefield solver, the new gridless model will now be used. The old one can still be used if needed by switching to `quasistatic_2d_legacy`.

The coverage options have been removed from pyproject.toml, as they were causing issues with the debugger when debugging tests.