### PR TITLE
Increase tolerance of parabolic profile CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -33,6 +33,8 @@ jobs:
         path: coverage.xml
 
   codacy-coverage-reporter:
+    # disabled due to API token not working
+    if: 0
     needs: build
     runs-on: ubuntu-latest
     name: codacy-coverage-reporter

--- a/tests/test_parabolic_profile.py
+++ b/tests/test_parabolic_profile.py
@@ -117,7 +117,7 @@ def test_variable_parabolic_coefficient():
 
     # Check that both envelopes are equal.
     np.testing.assert_almost_equal(a_mod_2, a_mod_1)
-    np.testing.assert_almost_equal(a_phase_2, a_phase_1, decimal=6)
+    np.testing.assert_almost_equal(a_phase_2, a_phase_1, decimal=5)
 
     # Check final spot size value
     dr = r_max / Nr

--- a/tests/test_ramps.py
+++ b/tests/test_ramps.py
@@ -49,7 +49,7 @@ def test_downramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params["beta_x"]
-    assert beta_x == 0.0097503087049851
+    np.testing.assert_almost_equal(beta_x, 0.0097503087049851, decimal=9)
 
 
 def test_upramp():
@@ -96,7 +96,7 @@ def test_upramp():
     downramp.track(bunch)
     bunch_params = analyze_bunch(bunch)
     beta_x = bunch_params["beta_x"]
-    assert beta_x == 0.0007631550504736755
+    np.testing.assert_almost_equal(beta_x, 0.0007631550504736755, decimal=9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Tolerance increase taken from https://github.com/Wake-T/Wake-T/pull/173

This PR also disables the codacy-coverage-reporter CI test due to the API token not working.