### PR TITLE
Disable Codacity CI test on forks

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -36,6 +36,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     name: codacy-coverage-reporter
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v2
       - name: Download code coverage results


### PR DESCRIPTION
Due to the need for the API token, the test only works on the main repo.