### PR TITLE
Add LaserStaticPlasma Model

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,10 +7,10 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-latest
   tools:
-    python: "3.11"
-    nodejs: "16"
+    python: "3.14"
+    nodejs: "26"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-latest
+  os: ubuntu-lts-latest
   tools:
     python: "3.14"
     nodejs: "26"

--- a/tests/test_laser_static_plasma.py
+++ b/tests/test_laser_static_plasma.py
@@ -5,7 +5,6 @@ import scipy.constants as ct
 import matplotlib.pyplot as plt
 from openpmd_viewer import OpenPMDTimeSeries
 from wake_t import PlasmaStage, GaussianPulse
-from wake_t.physics_models.laser.utils import unwrap
 
 
 tests_output_folder = "./tests_output"

--- a/tests/test_laser_static_plasma.py
+++ b/tests/test_laser_static_plasma.py
@@ -10,6 +10,7 @@ from wake_t.physics_models.laser.utils import unwrap
 
 tests_output_folder = "./tests_output"
 
+
 def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
     """Test evolution of Gaussian laser pulse in vacuum.
 
@@ -18,7 +19,9 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
     the final value of the sum of `a_mod` has not changed.
     """
     # Diagnostics directory.
-    test_dir = os.path.join(tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum")
+    test_dir = os.path.join(
+        tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum"
+    )
     diag_dir = os.path.join(test_dir, "diags")
 
     # Grid properties.
@@ -49,7 +52,7 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
 
     plasma = PlasmaStage(
         length=z_tot,
-        density=0.,
+        density=0.0,
         wakefield_model="laser_static_plasma",
         n_out=n_out,
         laser=laser,
@@ -59,8 +62,8 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
         xi_max=xi_max,
         n_r=nr,
         n_xi=nxi,
-        dz_fields= z_tot / nt,
-        field_diags=["rho", "a", "chi"]
+        dz_fields=z_tot / nt,
+        field_diags=["rho", "a", "chi"],
     )
 
     plasma.track(opmd_diag=True, diag_dir=diag_dir)
@@ -81,7 +84,6 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
     rayleigh_length = ct.pi * w_0**2 / l_0
     laser_w_an = w_0 * np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
     laser_a_an = a_0 / np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
-
 
     # Check that evolution is as expected.
     diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
@@ -116,7 +118,9 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
     the dimensions of the envelope arrays are as expected when using a subgrid.
     """
     # Diagnostics directory.
-    test_dir = os.path.join(tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum_with_subgrid")
+    test_dir = os.path.join(
+        tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum_with_subgrid"
+    )
     diag_dir = os.path.join(test_dir, "diags")
 
     # Grid properties.
@@ -151,7 +155,7 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
 
     plasma = PlasmaStage(
         length=z_tot,
-        density=0.,
+        density=0.0,
         wakefield_model="laser_static_plasma",
         n_out=n_out,
         laser=laser,
@@ -161,11 +165,11 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
         xi_max=xi_max,
         n_r=nr,
         n_xi=nxi,
-        dz_fields= z_tot / nt,
+        dz_fields=z_tot / nt,
         laser_envelope_substeps=2,
         laser_envelope_nxi=subgrid_nxi,
         laser_envelope_nr=subgrid_nr,
-        field_diags=["rho", "a", "chi"]
+        field_diags=["rho", "a", "chi"],
     )
 
     plasma.track(opmd_diag=True, diag_dir=diag_dir)
@@ -186,7 +190,6 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
     rayleigh_length = ct.pi * w_0**2 / l_0
     laser_w_an = w_0 * np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
     laser_a_an = a_0 / np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
-
 
     # Check that evolution is as expected.
     diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
@@ -214,7 +217,7 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
 
 def calculate_spot_size(a_env, dr):
     # Project envelope to r
-    a_env = a_env[a_env.shape[0]//2:,:].T
+    a_env = a_env[a_env.shape[0] // 2 :, :].T
 
     a_proj = np.sum(np.abs(a_env), axis=0)
 

--- a/tests/test_laser_static_plasma.py
+++ b/tests/test_laser_static_plasma.py
@@ -89,9 +89,9 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
     diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
 
     if diff_a >= 1e-3:
-        raise AssertionError(f'diff_a ({diff_a}) >= 1e-3')
+        raise AssertionError(f"diff_a ({diff_a}) >= 1e-3")
     if diff_w >= 1e-3:
-        raise AssertionError(f'diff_w ({diff_w}) >= 1e-3')
+        raise AssertionError(f"diff_w ({diff_w}) >= 1e-3")
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)
@@ -197,9 +197,9 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
     diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
 
     if diff_a >= 1e-3:
-        raise AssertionError(f'diff_a ({diff_a}) >= 1e-3')
+        raise AssertionError(f"diff_a ({diff_a}) >= 1e-3")
     if diff_w >= 1e-3:
-        raise AssertionError(f'diff_w ({diff_w}) >= 1e-3')
+        raise AssertionError(f"diff_w ({diff_w}) >= 1e-3")
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)

--- a/tests/test_laser_static_plasma.py
+++ b/tests/test_laser_static_plasma.py
@@ -88,8 +88,10 @@ def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
     diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
     diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
 
-    assert diff_a < 1e-3
-    assert diff_w < 1e-3
+    if diff_a >= 1e-3:
+        raise AssertionError(f'diff_a ({diff_a}) >= 1e-3')
+    if diff_w >= 1e-3:
+        raise AssertionError(f'diff_w ({diff_w}) >= 1e-3')
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)
@@ -194,8 +196,10 @@ def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
     diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
     diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
 
-    assert diff_a < 1e-3
-    assert diff_w < 1e-3
+    if diff_a >= 1e-3:
+        raise AssertionError(f'diff_a ({diff_a}) >= 1e-3')
+    if diff_w >= 1e-3:
+        raise AssertionError(f'diff_w ({diff_w}) >= 1e-3')
 
     # Check that solution hasn't changed.
     a_mod = np.abs(a_env)

--- a/tests/test_laser_static_plasma.py
+++ b/tests/test_laser_static_plasma.py
@@ -1,0 +1,256 @@
+import os
+import numpy as np
+from numpy.testing import assert_almost_equal
+import scipy.constants as ct
+import matplotlib.pyplot as plt
+from openpmd_viewer import OpenPMDTimeSeries
+from wake_t import PlasmaStage, GaussianPulse
+from wake_t.physics_models.laser.utils import unwrap
+
+
+tests_output_folder = "./tests_output"
+
+def test_laser_static_plasma_gaussian_in_vacuum(plot=False):
+    """Test evolution of Gaussian laser pulse in vacuum.
+
+    This test evolves a Gaussian laser pulse over a 1cm vacuum. It checks
+    that the evolution is in agreement with the analytical expectation and that
+    the final value of the sum of `a_mod` has not changed.
+    """
+    # Diagnostics directory.
+    test_dir = os.path.join(tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum")
+    diag_dir = os.path.join(test_dir, "diags")
+
+    # Grid properties.
+    xi_max = 20e-6
+    xi_min = -20e-6
+    r_max = 400e-6
+    nxi = 201
+    nr = 400
+    dr = r_max / nr
+
+    # Time steps.
+    z_tot = 1e-2
+    nt = 1000
+    n_out = 10
+
+    # Laser parameters in SI units
+    tau = 25e-15  # s
+    w_0 = 50e-6  # m
+    l_0 = 0.8e-6  # m
+    z_c = 0.0  # m
+    a_0 = 3
+    z_foc = z_tot / 2
+
+    # Create and initialize laser pulse.
+    laser = GaussianPulse(
+        z_c, l_0=l_0, w_0=w_0, a_0=a_0, tau=tau, z_foc=z_foc, polarization="circular"
+    )
+
+    plasma = PlasmaStage(
+        length=z_tot,
+        density=0.,
+        wakefield_model="laser_static_plasma",
+        n_out=n_out,
+        laser=laser,
+        laser_evolution=True,
+        r_max=r_max,
+        xi_min=xi_min,
+        xi_max=xi_max,
+        n_r=nr,
+        n_xi=nxi,
+        dz_fields= z_tot / nt,
+        field_diags=["rho", "a", "chi"]
+    )
+
+    plasma.track(opmd_diag=True, diag_dir=diag_dir)
+
+    ts = OpenPMDTimeSeries(os.path.join(diag_dir, "hdf5"))
+
+    laser_w = np.zeros(n_out + 1)
+    laser_a = np.zeros(n_out + 1)
+
+    for i, iteration in enumerate(ts.iterations):
+        a_env, info = ts.get_field("a", iteration=iteration)
+        dr = info.r[1] - info.r[0]
+        laser_w[i] = calculate_spot_size(a_env, dr)
+        laser_a[i] = calculate_a0(a_env)
+
+    # Calculate analytical evolution.
+    z = np.array(ts.t) * ct.c
+    rayleigh_length = ct.pi * w_0**2 / l_0
+    laser_w_an = w_0 * np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
+    laser_a_an = a_0 / np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
+
+
+    # Check that evolution is as expected.
+    diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
+    diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
+
+    assert diff_a < 1e-3
+    assert diff_w < 1e-3
+
+    # Check that solution hasn't changed.
+    a_mod = np.abs(a_env)
+    assert_almost_equal(np.sum(a_mod), 15000.76104411847, decimal=10)
+
+    # Make plots.
+    if plot:
+        plt.figure()
+        plt.plot(z, laser_w)
+        plt.plot(z, laser_w_an)
+
+        plt.figure()
+        plt.plot(z, laser_a)
+        plt.plot(z, laser_a_an)
+
+        plt.show()
+
+
+def test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=False):
+    """Test evolution of Gaussian laser pulse in vacuum using subgridding.
+
+    This test evolves a Gaussian laser pulse over a 1cm vacuum. It checks
+    that the evolution is in agreement with the analytical expectation and that
+    the final value of the sum of `a_mod` has not changed. It also checks that
+    the dimensions of the envelope arrays are as expected when using a subgrid.
+    """
+    # Diagnostics directory.
+    test_dir = os.path.join(tests_output_folder, "test_laser_static_plasma_gaussian_in_vacuum_with_subgrid")
+    diag_dir = os.path.join(test_dir, "diags")
+
+    # Grid properties.
+    xi_max = 20e-6
+    xi_min = -20e-6
+    r_max = 400e-6
+    nxi = 201
+    nr = 400
+    dr = r_max / nr
+
+    # Subgrid properties
+    subgrid_nxi = 400
+    subgrid_nr = 900
+
+    # Time steps.
+    z_tot = 1e-2
+    nt = 1000
+    n_out = 10
+
+    # Laser parameters in SI units
+    tau = 25e-15  # s
+    w_0 = 50e-6  # m
+    l_0 = 0.8e-6  # m
+    z_c = 0.0  # m
+    a_0 = 3
+    z_foc = z_tot / 2
+
+    # Create and initialize laser pulse.
+    laser = GaussianPulse(
+        z_c, l_0=l_0, w_0=w_0, a_0=a_0, tau=tau, z_foc=z_foc, polarization="circular"
+    )
+
+    plasma = PlasmaStage(
+        length=z_tot,
+        density=0.,
+        wakefield_model="laser_static_plasma",
+        n_out=n_out,
+        laser=laser,
+        laser_evolution=True,
+        r_max=r_max,
+        xi_min=xi_min,
+        xi_max=xi_max,
+        n_r=nr,
+        n_xi=nxi,
+        dz_fields= z_tot / nt,
+        laser_envelope_substeps=2,
+        laser_envelope_nxi=subgrid_nxi,
+        laser_envelope_nr=subgrid_nr,
+        field_diags=["rho", "a", "chi"]
+    )
+
+    plasma.track(opmd_diag=True, diag_dir=diag_dir)
+
+    ts = OpenPMDTimeSeries(os.path.join(diag_dir, "hdf5"))
+
+    laser_w = np.zeros(n_out + 1)
+    laser_a = np.zeros(n_out + 1)
+
+    for i, iteration in enumerate(ts.iterations):
+        a_env, info = ts.get_field("a", iteration=iteration)
+        dr = info.r[1] - info.r[0]
+        laser_w[i] = calculate_spot_size(a_env, dr)
+        laser_a[i] = calculate_a0(a_env)
+
+    # Calculate analytical evolution.
+    z = np.array(ts.t) * ct.c
+    rayleigh_length = ct.pi * w_0**2 / l_0
+    laser_w_an = w_0 * np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
+    laser_a_an = a_0 / np.sqrt(1 + ((z - z_foc) / rayleigh_length) ** 2)
+
+
+    # Check that evolution is as expected.
+    diff_w = np.max(np.abs(laser_w - laser_w_an) / laser_w_an)
+    diff_a = np.max(np.abs(laser_a - laser_a_an) / laser_a_an)
+
+    assert diff_a < 1e-3
+    assert diff_w < 1e-3
+
+    # Check that solution hasn't changed.
+    a_mod = np.abs(a_env)
+    assert_almost_equal(np.sum(a_mod), 15000.2361438053, decimal=10)
+
+    # Make plots.
+    if plot:
+        plt.figure()
+        plt.plot(z, laser_w)
+        plt.plot(z, laser_w_an)
+
+        plt.figure()
+        plt.plot(z, laser_a)
+        plt.plot(z, laser_a_an)
+
+        plt.show()
+
+
+def calculate_spot_size(a_env, dr):
+    # Project envelope to r
+    a_env = a_env[a_env.shape[0]//2:,:].T
+
+    a_proj = np.sum(np.abs(a_env), axis=0)
+
+    # Maximum is on axis
+    a_max = a_proj[0]
+
+    # Get first index of value below a_max / e
+    i_first = np.where(a_proj <= a_max / np.e)[0][0]
+
+    # Do linear interpolation to get more accurate value of w.
+    # We build a line y = a + b*x, where:
+    #     b = (y_2 - y_1) / (x_2 - x_1)
+    #     a = y_1 - b*x_1
+    #
+    #     y_1 is the value of a_proj at i_first - 1
+    #     y_2 is the value of a_proj at i_first
+    #     x_1 and x_2 are the radial positions of y_1 and y_2
+    #
+    # We can then determine the spot size by interpolating between y_1 and y_2,
+    # that is, do x = (y - a) / b, where y = a_max/e
+    y_1 = a_proj[i_first - 1]
+    y_2 = a_proj[i_first]
+    x_1 = (i_first - 1) * dr + dr / 2
+    x_2 = i_first * dr + dr / 2
+    b = (y_2 - y_1) / (x_2 - x_1)
+    a = y_1 - b * x_1
+    w = (a_max / np.e - a) / b
+    return w
+
+
+def calculate_a0(a_env):
+    a_mod = np.abs(a_env)
+    a0 = np.max(a_mod)
+    return a0
+
+
+if __name__ == "__main__":
+    test_laser_static_plasma_gaussian_in_vacuum(plot=True)
+    test_laser_static_plasma_gaussian_in_vacuum_with_subgrid(plot=True)

--- a/wake_t/beamline_elements/plasma_stage.py
+++ b/wake_t/beamline_elements/plasma_stage.py
@@ -23,6 +23,7 @@ wakefield_models = {
     "quasistatic_2d_legacy": wf.Quasistatic2DWakefield,
     "quasistatic_2d": wf.Quasistatic2DWakefieldIon,  # For backward compatibility
     "quasistatic_2d_ion": wf.Quasistatic2DWakefieldIon,
+    "laser_static_plasma": wf.LaserStaticPlasma,
 }
 
 

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -218,6 +218,7 @@ class RZWakefield(NumericalField):
         fld_attrs = []
         fld_arrays = []
         rho_norm = self.n_p * (-ct.e)
+        chi_norm = self.n_p * ct.e * ct.e * ct.mu_0 / ct.m_e
 
         # Add requested fields to diagnostics.
         if "E" in self.field_diags:
@@ -291,6 +292,11 @@ class RZWakefield(NumericalField):
                     }
                 ]
                 fld_arrays += [[np.ascontiguousarray(a)]]
+            if "chi" in self.field_diags:
+                fld_names += ["chi"]
+                fld_comps += [None]
+                fld_attrs += [{}]
+                fld_arrays += [[np.ascontiguousarray(self.chi.T[2:-2, 2:-2]) * chi_norm]]
 
         fld_comp_pos = [fld_position] * len(fld_names)
 

--- a/wake_t/fields/rz_wakefield.py
+++ b/wake_t/fields/rz_wakefield.py
@@ -296,7 +296,9 @@ class RZWakefield(NumericalField):
                 fld_names += ["chi"]
                 fld_comps += [None]
                 fld_attrs += [{}]
-                fld_arrays += [[np.ascontiguousarray(self.chi.T[2:-2, 2:-2]) * chi_norm]]
+                fld_arrays += [
+                    [np.ascontiguousarray(self.chi.T[2:-2, 2:-2]) * chi_norm]
+                ]
 
         fld_comp_pos = [fld_position] * len(fld_names)
 

--- a/wake_t/physics_models/plasma_wakefields/__init__.py
+++ b/wake_t/physics_models/plasma_wakefields/__init__.py
@@ -4,6 +4,7 @@ from .qs_cold_fluid_1x3p import NonLinearColdFluidWakefield
 from .qs_rz_baxevanis import Quasistatic2DWakefield
 from .focusing_blowout import FocusingBlowoutField
 from .qs_rz_baxevanis_ion import Quasistatic2DWakefieldIon
+from .laser_static_plasma import LaserStaticPlasma
 
 
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "Quasistatic2DWakefield",
     "FocusingBlowoutField",
     "Quasistatic2DWakefieldIon",
+    "LaserStaticPlasma",
 ]

--- a/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
+++ b/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
@@ -1,0 +1,139 @@
+from typing import List, Optional, Callable
+
+import numpy as np
+import scipy.constants as ct
+
+from wake_t.fields.rz_wakefield import RZWakefield
+from wake_t.physics_models.laser.laser_pulse import LaserPulse
+
+
+class LaserStaticPlasma(RZWakefield):
+    """
+    This model can be used to propagate laser pulses through a vacuum or a
+    specially varying static plasma density. Specifically, it can be used
+    when the laser is too weak to form a plasma wake, namely when a0 << 1.
+    This model does not calculate any electric or magnetic fields and should
+    not be used with a particle bunch.
+
+    Parameters
+    ----------
+    density_function : callable
+        Function that returns the density value at the given position z.
+        This parameter is given by the `PlasmaStage` and does not need
+        to be specified by the user.
+    r_max : float
+        Maximum radial position up to which laser will be calculated.
+    xi_min : float
+        Minimum longitudinal (speed of light frame) position up to which
+        laser will be calculated.
+    xi_max : float
+        Maximum longitudinal (speed of light frame) position up to which
+        laser will be calculated.
+    n_r : int
+        Number of grid elements along r to calculate the laser.
+    n_xi : int
+        Number of grid elements along xi to calculate the laser.
+    dz_fields : float, optional
+        Determines how often the laser and plasma refractive index should
+        be updated. If dz_fields=0 (default value), the laser is calculated
+        at every step of the Runge-Kutta solver for the beam particle evolution
+        (most expensive option). If specified, the laser is only
+        updated in steps determined by dz_fields. For example, if
+        dz_fields=10e-6, the laser is only updated every time
+        the simulation window advances by 10 micron. By default, if not
+        specified, the value of `dz_fields` will be `xi_max-xi_min`, i.e.,
+        the length the simulation box.
+    r_max_plasma : float, optional
+        Maximum radial extension of the plasma column. If ``None``, the
+        plasma extends up to the ``r_max`` boundary of the simulation box.
+    laser : LaserPulse, optional
+        Laser driver of the plasma stage.
+    laser_evolution : bool, optional
+        If True (default), the laser pulse is evolved
+        using a laser envelope model. If False, the pulse envelope stays
+        unchanged throughout the computation.
+    laser_envelope_substeps : int, optional
+        Number of substeps of the laser envelope solver per `dz_fields`.
+        The time step of the envelope solver is therefore
+        `dz_fields / c / laser_envelope_substeps`.
+    laser_envelope_nxi, laser_envelope_nr : int, optional
+        If given, the laser envelope will run in a grid of size
+        (`laser_envelope_nxi`, `laser_envelope_nr`) instead
+        of (`n_xi`, `n_r`). This allows the laser to run in a finer (or
+        coarser) grid than the plasma refractive index. It is not necessary
+        to specify both parameters. If one of them is not given, the resolution
+        of the plasma grid will be used for that direction.
+    laser_envelope_use_phase : bool, optional
+        Determines whether to take into account the terms related to the
+        longitudinal derivative of the complex phase in the envelope
+        solver.
+    field_diags : list, optional
+        List of fields to save to openpmd diagnostics.
+        By default ['rho', 'chi', 'a_mod', 'a_phase', 'a'].
+
+    See Also
+    --------
+    Quasistatic2DWakefieldIon
+
+    """
+
+    def __init__(
+        self,
+        density_function: Callable[[float], float],
+        r_max: float,
+        xi_min: float,
+        xi_max: float,
+        n_r: int,
+        n_xi: int,
+        dz_fields: Optional[float] = None,
+        r_max_plasma: Optional[float] = None,
+        laser: Optional[LaserPulse] = None,
+        laser_evolution: Optional[bool] = True,
+        laser_envelope_substeps: Optional[int] = 1,
+        laser_envelope_nxi: Optional[int] = None,
+        laser_envelope_nr: Optional[int] = None,
+        laser_envelope_use_phase: Optional[bool] = True,
+        field_diags: Optional[List[str]] = ["rho", "chi", "a_mod", "a_phase", "a"],
+    ) -> None:
+        super().__init__(
+            density_function=density_function,
+            r_max=r_max,
+            xi_min=xi_min,
+            xi_max=xi_max,
+            n_r=n_r,
+            n_xi=n_xi,
+            dz_fields=dz_fields,
+            laser=laser,
+            laser_evolution=laser_evolution,
+            laser_envelope_substeps=laser_envelope_substeps,
+            laser_envelope_nxi=laser_envelope_nxi,
+            laser_envelope_nr=laser_envelope_nr,
+            laser_envelope_use_phase=laser_envelope_use_phase,
+            field_diags=field_diags,
+            model_name="laser_in_vacuum",
+        )
+        self.r_max_plasma = r_max_plasma
+
+    def _calculate_wakefield(self, bunches):
+
+        # Use a reference plasma density for internal units to be able to simulate vacuum
+        self.n_p = 1e23
+
+        # Get laser envelope
+        if self.laser is not None:
+            a_env = np.abs(self.laser.get_envelope())
+            # If linearly polarized, divide by sqrt(2) so that the
+            # ponderomotive force on the plasma particles is correct.
+            if self.laser.polarization == "linear":
+                a_env /= np.sqrt(2)
+        else:
+            a_env = np.zeros((self.n_xi, self.n_r))
+
+        density_elec = self.density_function(self.t * ct.c, self.r_fld)
+        if self.r_max_plasma is not None:
+            density_elec = np.where(self.r_fld > self.r_max_plasma, 0, density_elec)
+        # Gamma for particles with no momentum but that see a laser
+        gamma_elec = 0.5 * (2 + a_env**2)
+        # Convert to normalized units
+        self.rho[2:-2, 2:-2] = (density_elec / self.n_p) * gamma_elec
+        self.chi[2:-2, 2:-2] = (density_elec / self.n_p)

--- a/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
+++ b/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
@@ -136,4 +136,4 @@ class LaserStaticPlasma(RZWakefield):
         gamma_elec = 0.5 * (2 + a_env**2)
         # Convert to normalized units
         self.rho[2:-2, 2:-2] = (density_elec / self.n_p) * gamma_elec
-        self.chi[2:-2, 2:-2] = (density_elec / self.n_p)
+        self.chi[2:-2, 2:-2] = density_elec / self.n_p

--- a/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
+++ b/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
@@ -93,7 +93,9 @@ class LaserStaticPlasma(RZWakefield):
         laser_envelope_nxi: Optional[int] = None,
         laser_envelope_nr: Optional[int] = None,
         laser_envelope_use_phase: Optional[bool] = True,
-        field_diags: Optional[List[str]] = (lambda: ["rho", "chi", "a_mod", "a_phase", "a"])(),
+        field_diags: Optional[List[str]] = (
+            lambda: ["rho", "chi", "a_mod", "a_phase", "a"]
+        )(),
     ) -> None:
         super().__init__(
             density_function=density_function,

--- a/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
+++ b/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
@@ -93,7 +93,7 @@ class LaserStaticPlasma(RZWakefield):
         laser_envelope_nxi: Optional[int] = None,
         laser_envelope_nr: Optional[int] = None,
         laser_envelope_use_phase: Optional[bool] = True,
-        field_diags: Optional[List[str]] = ["rho", "chi", "a_mod", "a_phase", "a"],
+        field_diags: Optional[List[str]] = (lambda: ["rho", "chi", "a_mod", "a_phase", "a"])(),
     ) -> None:
         super().__init__(
             density_function=density_function,

--- a/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
+++ b/wake_t/physics_models/plasma_wakefields/laser_static_plasma.py
@@ -93,10 +93,10 @@ class LaserStaticPlasma(RZWakefield):
         laser_envelope_nxi: Optional[int] = None,
         laser_envelope_nr: Optional[int] = None,
         laser_envelope_use_phase: Optional[bool] = True,
-        field_diags: Optional[List[str]] = (
-            lambda: ["rho", "chi", "a_mod", "a_phase", "a"]
-        )(),
+        field_diags: Optional[List[str]] = None,
     ) -> None:
+        if field_diags is None:
+            field_diags = ["rho", "chi", "a_mod", "a_phase", "a"]
         super().__init__(
             density_function=density_function,
             r_max=r_max,


### PR DESCRIPTION
This PR adds a "laser_static_plasma" wakefield_model to PlasmaStage to make it easier to use the laser envelope model without plasma particles. Internally it always uses a reference plasma density of 1e23 so that the user supplied plasma density can be zero.

Additionally chi can now be output in the openPMD diagnostics.